### PR TITLE
fix(benchmark): guard span_text_cb with LV_USE_SPAN instead of LV_USE…

### DIFF
--- a/demos/benchmark/lv_demo_benchmark.c
+++ b/demos/benchmark/lv_demo_benchmark.c
@@ -84,8 +84,10 @@ static void arc_anim(benchmark_context_t * context, lv_obj_t * obj);
 
 static lv_obj_t * card_create(void);
 
+#if LV_USE_SPAN
 static void spans_init(lv_obj_t * spans);
 static void spans_text_add(lv_obj_t * spans, const lv_font_t * font, const char * text);
+#endif
 
 #if LV_USE_SVG
     static void svg_create(benchmark_context_t * context, const char * src);
@@ -179,6 +181,7 @@ static void label_tiny_ttf_text_cb(benchmark_context_t * context)
 }
 #endif
 
+#if LV_USE_SPAN
 static void span_text_cb(benchmark_context_t * context)
 {
     lv_obj_set_layout(lv_screen_active(), 0);
@@ -190,6 +193,7 @@ static void span_text_cb(benchmark_context_t * context)
 
     shake_anim(context, spans, - lv_display_get_vertical_resolution(NULL) / 3);
 }
+#endif
 
 #if LV_USE_SVG
 static void svg_tiger_cb(benchmark_context_t * context)
@@ -620,7 +624,9 @@ static scene_dsc_t scenes[] = {
     {.name = "Screen sized text",               .scene_time = 5000,  .create_cb = screen_sized_text_cb},
     {.name = "Multiple arcs",                   .scene_time = 3000,  .create_cb = multiple_arcs_cb},
 
+#if LV_USE_SPAN
     {.name = "Span text",                       .scene_time = 3000,  .create_cb = span_text_cb},
+#endif
 #if LV_USE_FREETYPE
     {.name = "FreeType span text(bitmap)",      .scene_time = 3000,  .create_cb = freetype_span_text_bitmap_cb},
     {.name = "FreeType span text(outline)",     .scene_time = 3000,  .create_cb = freetype_span_text_outline_cb},
@@ -1089,7 +1095,7 @@ static lv_obj_t * card_create(void)
     return panel;
 }
 
-#if LV_USE_FREETYPE || TEST_TINY_TTF
+#if LV_USE_SPAN
 static void spans_init(lv_obj_t * spans)
 {
     lv_obj_set_width(spans, LV_PCT(100));


### PR DESCRIPTION
Summary
Fix linker error undefined reference to 'spans_init' when LV_USE_DEMO_BENCHMARK=y but LV_USE_SPAN is not enabled.
Problem
The span_text_cb function and its helper functions (spans_init, spans_text_add) use lv_spangroup_* APIs which require LV_USE_SPAN to be enabled. However, the function definitions were incorrectly guarded by #if LV_USE_FREETYPE || TEST_TINY_TTF, while the function call site had no guard at all.
This causes a linker error when:
- LV_USE_DEMO_BENCHMARK=y (benchmark demo enabled)
- LV_USE_SPAN is not set (span widget disabled)
- LV_USE_FREETYPE is not set (freetype disabled)
Fix
Replace #if LV_USE_FREETYPE || TEST_TINY_TTF with #if LV_USE_SPAN for:
- Function declarations (line 87-88)
- span_text_cb function definition (line 182-192)
- Scene registration in scenes[] array (line 624)
- spans_init / spans_text_add definitions (line 1095)
Impact
- No behavior change when LV_USE_SPAN=1 (span widget enabled)
- Correctly skips span benchmark scene when LV_USE_SPAN=0
- Fixes build for configurations that enable benchmark demo without span widget
Testing
Build verified with BES2600 audio config (LV_USE_DEMO_BENCHMARK=y, LV_USE_SPAN not set):
./build.sh vendor/bes/boards/best2003_ep/aos_evb/configs/audio -j20 ✅