### PR TITLE
fix: remove duplicate semicolons, add missing NULL checks, and use lv_malloc_zeroed

### DIFF
--- a/src/core/lv_obj_pos.c
+++ b/src/core/lv_obj_pos.c
@@ -972,7 +972,7 @@ void lv_obj_set_transform(lv_obj_t * obj, const lv_matrix_t * matrix)
 
     lv_obj_allocate_spec_attr(obj);
     if(!obj->spec_attr->matrix) {
-        obj->spec_attr->matrix = lv_malloc(sizeof(lv_matrix_t));;
+        obj->spec_attr->matrix = lv_malloc(sizeof(lv_matrix_t));
         LV_ASSERT_MALLOC(obj->spec_attr->matrix);
     }
 

--- a/src/font/lv_binfont_loader.c
+++ b/src/font/lv_binfont_loader.c
@@ -294,9 +294,7 @@ static int32_t load_cmaps(lv_fs_file_t * fp, lv_font_fmt_txt_dsc_t * font_dsc, u
     }
 
     lv_font_fmt_txt_cmap_t * cmaps =
-        lv_malloc(cmaps_subtables_count * sizeof(lv_font_fmt_txt_cmap_t));
-
-    lv_memset(cmaps, 0, cmaps_subtables_count * sizeof(lv_font_fmt_txt_cmap_t));
+        lv_malloc_zeroed(cmaps_subtables_count * sizeof(lv_font_fmt_txt_cmap_t));
 
     font_dsc->cmaps = cmaps;
     font_dsc->cmap_num = cmaps_subtables_count;
@@ -319,9 +317,7 @@ static int32_t load_glyph(lv_fs_file_t * fp, lv_font_fmt_txt_dsc_t * font_dsc,
     }
 
     lv_font_fmt_txt_glyph_dsc_t * glyph_dsc = (lv_font_fmt_txt_glyph_dsc_t *)
-                                              lv_malloc(loca_count * sizeof(lv_font_fmt_txt_glyph_dsc_t));
-
-    lv_memset(glyph_dsc, 0, loca_count * sizeof(lv_font_fmt_txt_glyph_dsc_t));
+                                              lv_malloc_zeroed(loca_count * sizeof(lv_font_fmt_txt_glyph_dsc_t));
 
     font_dsc->glyph_dsc = glyph_dsc;
 
@@ -458,9 +454,7 @@ static int32_t load_glyph(lv_fs_file_t * fp, lv_font_fmt_txt_dsc_t * font_dsc,
 static bool lvgl_load_font(lv_fs_file_t * fp, lv_font_t * font)
 {
     lv_font_fmt_txt_dsc_t * font_dsc = (lv_font_fmt_txt_dsc_t *)
-                                       lv_malloc(sizeof(lv_font_fmt_txt_dsc_t));
-
-    lv_memset(font_dsc, 0, sizeof(lv_font_fmt_txt_dsc_t));
+                                       lv_malloc_zeroed(sizeof(lv_font_fmt_txt_dsc_t));
 
     font->dsc = font_dsc;
 
@@ -575,9 +569,7 @@ int32_t load_kern(lv_fs_file_t * fp, lv_font_fmt_txt_dsc_t * font_dsc, uint8_t f
     }
 
     if(0 == kern_format_type) { /*sorted pairs*/
-        lv_font_fmt_txt_kern_pair_t * kern_pair = lv_malloc(sizeof(lv_font_fmt_txt_kern_pair_t));
-
-        lv_memset(kern_pair, 0, sizeof(lv_font_fmt_txt_kern_pair_t));
+        lv_font_fmt_txt_kern_pair_t * kern_pair = lv_malloc_zeroed(sizeof(lv_font_fmt_txt_kern_pair_t));
 
         font_dsc->kern_dsc = kern_pair;
         font_dsc->kern_classes = 0;
@@ -613,9 +605,7 @@ int32_t load_kern(lv_fs_file_t * fp, lv_font_fmt_txt_dsc_t * font_dsc, uint8_t f
     }
     else if(3 == kern_format_type) { /*array M*N of classes*/
 
-        lv_font_fmt_txt_kern_classes_t * kern_classes = lv_malloc(sizeof(lv_font_fmt_txt_kern_classes_t));
-
-        lv_memset(kern_classes, 0, sizeof(lv_font_fmt_txt_kern_classes_t));
+        lv_font_fmt_txt_kern_classes_t * kern_classes = lv_malloc_zeroed(sizeof(lv_font_fmt_txt_kern_classes_t));
 
         font_dsc->kern_dsc = kern_classes;
         font_dsc->kern_classes = 1;

--- a/src/font/lv_font_fmt_txt.c
+++ b/src/font/lv_font_fmt_txt.c
@@ -374,11 +374,16 @@ static void decompress(const uint8_t * in, uint8_t * out, int32_t w, int32_t h, 
     rle_init(in, bpp);
 
     uint8_t * line_buf1 = lv_malloc(w);
+    if(line_buf1 == NULL) return;
 
     uint8_t * line_buf2 = NULL;
 
     if(prefilter) {
         line_buf2 = lv_malloc(w);
+        if(line_buf2 == NULL) {
+            lv_free(line_buf1);
+            return;
+        }
     }
 
     decompress_line(line_buf1, w);

--- a/src/libs/thorvg/tvgRender.h
+++ b/src/libs/thorvg/tvgRender.h
@@ -241,7 +241,7 @@ struct RenderShape
     {
         if (!stroke) return 4.0f;
 
-        return stroke->miterlimit;;
+        return stroke->miterlimit;
     }
 };
 

--- a/src/others/file_explorer/lv_file_explorer.c
+++ b/src/others/file_explorer/lv_file_explorer.c
@@ -85,7 +85,7 @@ void lv_file_explorer_set_quick_access_path(lv_obj_t * obj, lv_file_explorer_dir
     lv_file_explorer_t * explorer = (lv_file_explorer_t *)obj;
 
     /*If path is unavailable */
-    if((path == NULL) || (lv_strlen(path) <= 0)) return;
+    if((path == NULL) || (lv_strlen(path) == 0)) return;
 
     char ** dir_str = NULL;
     switch(dir) {

--- a/src/others/ime/lv_ime_pinyin.c
+++ b/src/others/ime/lv_ime_pinyin.c
@@ -681,7 +681,8 @@ static void lv_ime_pinyin_kb_event(lv_event_t * e)
             return;
         }
         else if(lv_strcmp(txt, "123") == 0) {
-            for(uint16_t i = 0; i < lv_strlen(txt); i++)
+            uint16_t txt_len = lv_strlen(txt);
+            for(uint16_t i = 0; i < txt_len; i++)
                 lv_textarea_delete_char(ta);
 
             pinyin_ime_clear_data(obj);

--- a/src/others/sysmon/lv_sysmon.c
+++ b/src/others/sysmon/lv_sysmon.c
@@ -208,7 +208,7 @@ static void mem_observer_cb(lv_observer_t * observer, lv_subject_t * subject)
     lv_obj_t * label = lv_observer_get_target(observer);
     const lv_mem_monitor_t * mon = lv_subject_get_pointer(subject);
 
-    size_t used_size = mon->total_size - mon->free_size;;
+    size_t used_size = mon->total_size - mon->free_size;
     size_t used_kb = used_size / 1024;
     size_t used_kb_tenth = (used_size - (used_kb * 1024)) / 102;
     size_t max_used_kb = mon->max_used / 1024;

--- a/src/widgets/span/lv_span.c
+++ b/src/widgets/span/lv_span.c
@@ -972,7 +972,7 @@ static int32_t lv_span_get_style_text_decor(lv_obj_t * par, lv_span_t * span)
     lv_style_value_t value;
     lv_result_t res = lv_style_get_prop(&span->style, LV_STYLE_TEXT_DECOR, &value);
     if(res != LV_RESULT_OK) {
-        decor = (lv_text_decor_t)lv_obj_get_style_text_decor(par, LV_PART_MAIN);;
+        decor = (lv_text_decor_t)lv_obj_get_style_text_decor(par, LV_PART_MAIN);
     }
     else {
         decor = (int32_t)value.num;

--- a/src/widgets/table/lv_table.c
+++ b/src/widgets/table/lv_table.c
@@ -999,7 +999,7 @@ static lv_result_t get_pressed_cell(lv_obj_t * obj, uint32_t * row, uint32_t * c
     }
 
     if(row) {
-        int32_t y = p.y + lv_obj_get_scroll_y(obj);;
+        int32_t y = p.y + lv_obj_get_scroll_y(obj);
         y -= obj->coords.y1;
         y -= lv_obj_get_style_pad_top(obj, LV_PART_MAIN);
 

--- a/src/widgets/textarea/lv_textarea.c
+++ b/src/widgets/textarea/lv_textarea.c
@@ -1016,6 +1016,7 @@ static void pwd_char_hider(lv_obj_t * obj)
     const char * bullet = lv_textarea_get_password_bullet(obj);
     const size_t bullet_len = lv_strlen(bullet);
     char * txt_tmp = lv_malloc(enc_len * bullet_len + 1);
+    if(txt_tmp == NULL) return;
 
     uint32_t i;
     for(i = 0; i < enc_len; i++) {


### PR DESCRIPTION
## Summary

- Remove 5 duplicate semicolons across `lv_obj_pos.c`, `lv_sysmon.c`, `lv_table.c`, `lv_span.c`, and `tvgRender.h`
- Replace `lv_malloc` + `lv_memset(0)` with `lv_malloc_zeroed` in `lv_binfont_loader.c` (5 occurrences) for cleaner and safer zero-initialized allocation
- Add missing NULL checks after `lv_malloc` in `lv_textarea.c` (`pwd_char_hider`) and `lv_font_fmt_txt.c` (`decompress`) to prevent NULL pointer dereference on allocation failure
- Fix unsigned comparison `lv_strlen() <= 0` to `== 0` in `lv_file_explorer.c` (`lv_strlen` returns `size_t`, so `<= 0` is semantically misleading)
- Hoist `lv_strlen()` out of `for` loop condition in `lv_ime_pinyin.c` to avoid redundant recalculation on each iteration

## Details

### Duplicate semicolons
Harmless but noisy — removed `;;` in 5 locations across widgets, core, and libs.

### lv_malloc_zeroed
`lv_binfont_loader.c` had 5 instances of the pattern:
```c
ptr = lv_malloc(size);
lv_memset(ptr, 0, size);
```
Replaced with single `lv_malloc_zeroed(size)` call. This is cleaner and also avoids a potential NULL dereference if `lv_malloc` fails (memset on NULL is undefined behavior).

### Missing NULL checks
- `lv_textarea.c:pwd_char_hider()` — `lv_malloc` result was used directly without NULL check
- `lv_font_fmt_txt.c:decompress()` — two `lv_malloc` calls without NULL checks; added proper cleanup (free first buffer if second allocation fails)

### Unsigned comparison
`lv_strlen()` returns `size_t` (unsigned). The check `lv_strlen(path) <= 0` is equivalent to `== 0` but misleading since an unsigned value can never be negative.

### Loop optimization
`lv_strlen(txt)` was called on every iteration of a `for` loop. Hoisted to a local variable before the loop.

## Test plan
- [ ] Verify build succeeds with no new warnings
- [ ] Existing tests pass without regressions
- [ ] Changes are mechanical/safe — no behavioral changes except added NULL-check early returns

🤖 Generated with [Claude Code](https://claude.com/claude-code)