### PR TITLE
drivers/nuttx: use /dev/lcd0 as default fb_path when LV_USE_NUTTX_LCD

### DIFF
--- a/src/drivers/nuttx/lv_nuttx_entry.c
+++ b/src/drivers/nuttx/lv_nuttx_entry.c
@@ -96,7 +96,11 @@ void lv_nuttx_dsc_init(lv_nuttx_dsc_t * dsc)
         return;
 
     lv_memzero(dsc, sizeof(lv_nuttx_dsc_t));
+#if LV_USE_NUTTX_LCD
+    dsc->fb_path = "/dev/lcd0";
+#else
     dsc->fb_path = "/dev/fb0";
+#endif
     dsc->input_path = "/dev/input0";
 
 #ifdef CONFIG_UINPUT_TOUCH


### PR DESCRIPTION
lv_nuttx_dsc_init() hardcoded the default device path to /dev/fb0 (framebuffer device). Small displays like the ILI9341 run in LCD character-device mode (/dev/lcd0), so the mismatched path prevented vapp from opening the display device.

Select the default path based on LV_USE_NUTTX_LCD: use /dev/lcd0 when the NuttX LCD driver is enabled, otherwise keep /dev/fb0.

*Note: Please adhere to [Contributing Guidelines](https://github.com/open-vela/docs/blob/dev/CONTRIBUTING.md).*

## Summary

*Update this section with information on why change is necessary,
 what it exactly does and how, if new feature shows up, provide
 references (dependencies, similar problems and solutions), etc.*

## Impact

*Update this section, where applicable, on how change affects users,
 build process, hardware, documentation, security, compatibility, etc.*

## Testing

*Update this section with details on how did you verify the change,
 what Host was used for build (OS, CPU, compiler, ..), what Target was
 used for verification (arch, board:config, ..), etc. Providing build
 and runtime logs from before and after change is highly appreciated.*

