### PR TITLE
drivers/nuttx: fbdev refresh without vsync queue; touchscreen coordinate fixes

### DIFF
--- a/src/drivers/nuttx/lv_nuttx_fbdev.c
+++ b/src/drivers/nuttx/lv_nuttx_fbdev.c
@@ -175,23 +175,12 @@ errout:
 
 static void display_refr_timer_cb(lv_timer_t * tmr)
 {
-    lv_display_t * disp = lv_timer_get_user_data(tmr);
-    lv_nuttx_fb_t * dsc = lv_display_get_driver_data(disp);
-    struct pollfd pfds[1];
+    /* This MIPI-DSI panel has no vsync pan queue.  Waiting for POLLOUT
+     * leaves the front buffer at memset(0) forever (backlight on, black
+     * screen) even though LVGL is running.
+     */
 
-    lv_memzero(pfds, sizeof(pfds));
-    pfds[0].fd = dsc->fd;
-    pfds[0].events = POLLOUT;
-
-    /* Query free fb to draw */
-
-    if(poll(pfds, 1, 0) < 0) {
-        return;
-    }
-
-    if(pfds[0].revents & POLLOUT) {
-        _lv_display_refr_timer(tmr);
-    }
+    _lv_display_refr_timer(tmr);
 }
 
 static void flush_cb(lv_display_t * disp, const lv_area_t * area, uint8_t * color_p)

--- a/src/drivers/nuttx/lv_nuttx_touchscreen.c
+++ b/src/drivers/nuttx/lv_nuttx_touchscreen.c
@@ -154,14 +154,13 @@ static void process_single_touch(lv_indev_t * drv,
         data->point.x = LV_CLAMP(0, sample->point[0].x, hor_max);
         data->point.y = LV_CLAMP(0, sample->point[0].y, ver_max);
         touchscreen->last_state = LV_INDEV_STATE_PRESSED;
-
-        if(touch_flags & TOUCH_DOWN) {
-            touchscreen->primary_point.id = sample->point[0].id;
-            touchscreen->primary_point.x = data->point.x;
-            touchscreen->primary_point.y = data->point.y;
-        }
+        touchscreen->primary_point.id = sample->point[0].id;
+        touchscreen->primary_point.x = data->point.x;
+        touchscreen->primary_point.y = data->point.y;
     }
     else if(touch_flags & TOUCH_UP) {
+        data->point.x = touchscreen->primary_point.x;
+        data->point.y = touchscreen->primary_point.y;
         touchscreen->primary_point.id = UINT8_MAX;
         touchscreen->last_state = LV_INDEV_STATE_RELEASED;
     }
@@ -302,13 +301,19 @@ static void touchscreen_read(lv_indev_t * drv, lv_indev_data_t * data)
     else {
         /* Read first sample */
         if(!touchscreen_read_sample(touchscreen)) {
-            /* No sample available, return last state */
+            /* No sample available, return last state.
+             * lv_indev zeroes this struct every call: leaving point at
+             * (0,0) while PRESSED makes every tap jump to the corner
+             * and widgets treat it as a drag, not a click.
+             */
 #if LV_USE_GESTURE_RECOGNITION
             if(touchscreen->active_points > 1) {
                 return;
             }
 #endif
             data->state = touchscreen->last_state;
+            data->point.x = touchscreen->primary_point.x;
+            data->point.y = touchscreen->primary_point.y;
             return;
         }
 


### PR DESCRIPTION
Two driver fixes found while bringing up LVGL on the ESP32-P4-Function-EV-Board (7in 1024x600 EK79007 MIPI-DSI panel + GT911 touch), both verified on hardware:

- **lv_nuttx_fbdev**: run the display refresh timer unconditionally instead of gating it on the framebuffer's POLLOUT. A panel driven as a continuous DPI/DSI video stream has no vsync pan queue, so POLLOUT never signals and the refresh timer never runs: LVGL appears alive but the front buffer keeps its boot contents forever (backlight on, black screen).
- **lv_nuttx_touchscreen**: `lv_indev` zeroes the read data on every callback, so the no-sample path and the touch-up path must return the last known coordinates. Leaving the point at (0,0) while the state is PRESSED turns every tap into a corner-jump drag, which widgets treat as a scroll instead of a click.

Companion PRs: open-vela/nuttx#342, open-vela/nuttx-apps#115, open-vela/contest2026_338_xigoukeji#1 (team 338).

🤖 Generated with [Claude Code](https://claude.com/claude-code)