### PR TITLE
feat(draw/sifli): add EPIC hardware acceleration for LVGL

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -328,6 +328,24 @@ menu "LVGL configuration"
 			help
 				Uses SDL renderer API
 
+		config LV_USE_SIFLI_EPIC
+			bool "Use SiFli EPIC draw accelerator"
+			default n
+			depends on BSP_USING_EPIC
+			help
+				Use the SiFli EPIC hardware accelerator for supported LVGL
+				draw tasks and framebuffer copy fallback.
+
+		config LV_USE_SIFLI_EPIC_DRAW_THREAD
+			bool "Use a dedicated SiFli EPIC draw thread"
+			default n
+			depends on LV_USE_SIFLI_EPIC && LV_USE_OS > 0
+
+		config LV_USE_SIFLI_EPIC_ASSERT
+			bool "Enable SiFli EPIC asserts"
+			default n
+			depends on LV_USE_SIFLI_EPIC
+
 		config LV_USE_DRAW_VG_LITE
 			bool "Use VG-Lite GPU"
 			default n
@@ -421,6 +439,12 @@ menu "LVGL configuration"
 		config LV_USE_DRAW_G2D
 			bool "Use Sunxi G2D platform"
 			default n
+
+		config LV_USE_DRAW_EPIC
+			bool "Use SiFli EPIC GPU for hardware acceleration"
+			default n
+			help
+				Enable SiFli EPIC GPU hardware acceleration for LVGL rendering.
 
 		config LV_USE_VECTOR_GRAPHIC
 			bool "Use Vector Graphic APIs"

--- a/src/draw/sifli/epic/lv_draw_buf_sifli_epic.c
+++ b/src/draw/sifli/epic/lv_draw_buf_sifli_epic.c
@@ -1,0 +1,137 @@
+/**
+ * @file lv_draw_buf_sifli_epic.c
+ *
+ */
+
+/**
+ * Copyright 2024 SiFli Technologies
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+/*********************
+ *      INCLUDES
+ *********************/
+
+#include "lv_draw_sifli_epic.h"
+
+#if LV_USE_SIFLI_EPIC
+#include "../../../core/lv_global.h"
+#include "../../../misc/lv_log.h"
+#include "lv_sifli_epic_cfg.h"
+
+/*********************
+ *      DEFINES
+ *********************/
+
+#define font_draw_buf_handlers &(LV_GLOBAL_DEFAULT()->font_draw_buf_handlers)
+#define image_cache_draw_buf_handlers &(LV_GLOBAL_DEFAULT()->image_cache_draw_buf_handlers)
+
+/**********************
+ *      TYPEDEFS
+ **********************/
+
+/**********************
+ *  STATIC PROTOTYPES
+ **********************/
+
+static void buf_invalidate_cache(const lv_draw_buf_t * draw_buf, const lv_area_t * area);
+static void buf_flush_cache(const lv_draw_buf_t * draw_buf, const lv_area_t * area);
+static bool draw_buf_area_to_cache_region(const lv_draw_buf_t * draw_buf, const lv_area_t * area,
+                                          uint8_t ** start, uint32_t * size);
+
+/**********************
+ *  STATIC VARIABLES
+ **********************/
+
+/**********************
+ *      MACROS
+ **********************/
+
+/**********************
+ *   GLOBAL FUNCTIONS
+ **********************/
+
+void lv_draw_buf_sifli_epic_init_handlers(void)
+{
+    lv_draw_buf_handlers_t * handlers = lv_draw_buf_get_handlers();
+    lv_draw_buf_handlers_t * font_handlers = font_draw_buf_handlers;
+    lv_draw_buf_handlers_t * image_handlers = image_cache_draw_buf_handlers;
+
+    handlers->invalidate_cache_cb = buf_invalidate_cache;
+    handlers->flush_cache_cb = buf_flush_cache;
+    font_handlers->invalidate_cache_cb = buf_invalidate_cache;
+    font_handlers->flush_cache_cb = buf_flush_cache;
+    image_handlers->invalidate_cache_cb = buf_invalidate_cache;
+    image_handlers->flush_cache_cb = buf_flush_cache;
+}
+
+/**********************
+ *   STATIC FUNCTIONS
+ **********************/
+
+static void buf_invalidate_cache(const lv_draw_buf_t * draw_buf, const lv_area_t * area)
+{
+    uint8_t * start;
+    uint32_t size;
+
+    if(draw_buf == NULL || draw_buf->data == NULL) {
+        return;
+    }
+
+    if(!draw_buf_area_to_cache_region(draw_buf, area, &start, &size)) {
+        return;
+    }
+
+    if(!lv_epic_is_cached_ram((uint32_t)(uintptr_t)start, size)) {
+        return;
+    }
+
+    lv_epic_invalidate_cache_range(start, size);
+}
+
+static void buf_flush_cache(const lv_draw_buf_t * draw_buf, const lv_area_t * area)
+{
+    uint8_t * start;
+    uint32_t size;
+
+    if(draw_buf == NULL || draw_buf->data == NULL) {
+        return;
+    }
+
+    if(!draw_buf_area_to_cache_region(draw_buf, area, &start, &size)) {
+        return;
+    }
+
+    if(!lv_epic_is_cached_ram((uint32_t)(uintptr_t)start, size)) {
+        return;
+    }
+
+    lv_epic_flush_cache_range(start, size);
+}
+
+static bool draw_buf_area_to_cache_region(const lv_draw_buf_t * draw_buf, const lv_area_t * area,
+                                          uint8_t ** start, uint32_t * size)
+{
+    LV_ASSERT_NULL(draw_buf);
+    LV_ASSERT_NULL(start);
+    LV_ASSERT_NULL(size);
+
+    if(draw_buf->data == NULL) {
+        return false;
+    }
+
+    uint32_t stride = draw_buf->header.stride;
+    uint32_t height = area ? (uint32_t)lv_area_get_height(area) : draw_buf->header.h;
+    int32_t y1 = area ? area->y1 : 0;
+
+    if(height == 0U || y1 < 0) {
+        return false;
+    }
+
+    *start = draw_buf->data + (uint32_t)y1 * stride;
+    *size = stride * height;
+    return true;
+}
+
+#endif /*LV_USE_SIFLI_EPIC*/

--- a/src/draw/sifli/epic/lv_draw_sifli_epic.c
+++ b/src/draw/sifli/epic/lv_draw_sifli_epic.c
@@ -1,0 +1,543 @@
+/**
+ * @file lv_draw_sifli_epic.c
+ *
+ */
+
+/**
+ * Copyright 2024 SiFli Technologies
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+/*********************
+ *      INCLUDES
+ *********************/
+
+#include "lv_draw_sifli_epic.h"
+
+#if LV_USE_SIFLI_EPIC
+#include "lv_sifli_epic_utils.h"
+#include "lv_sifli_epic_cfg.h"
+#include "../../../display/lv_display_private.h"
+#include "../../../font/lv_font.h"
+#include "../../../misc/lv_log.h"
+#include "../../../misc/lv_text.h"
+
+#if defined(__NuttX__) && LV_USE_SIFLI_EPIC_DRAW_THREAD
+#error "SiFli EPIC draw thread is not supported on NuttX"
+#endif
+
+/*********************
+ *      DEFINES
+ *********************/
+
+#define DRAW_UNIT_ID_SIFLI_EPIC 11
+
+/**********************
+ *  STATIC PROTOTYPES
+ **********************/
+
+/**
+ * Evaluate a task and set the score and preferred EPIC unit.
+ * @param draw_unit Draw unit
+ * @param task Draw task
+ * @return 1 if task is preferred, 0 otherwise
+ */
+static int32_t _epic_evaluate(lv_draw_unit_t * draw_unit, lv_draw_task_t * task);
+
+/**
+ * Dispatch a task to the EPIC unit.
+ * @param draw_unit Draw unit
+ * @param layer Layer to draw
+ * @return 1 if task was dispatched, 0 otherwise
+ */
+static int32_t _epic_dispatch(lv_draw_unit_t * draw_unit, lv_layer_t * layer);
+
+/**
+ * Delete the EPIC draw unit.
+ * @param draw_unit Draw unit
+ * @return Always returns 0
+ */
+static int32_t _epic_delete(lv_draw_unit_t * draw_unit);
+
+#if LV_USE_SIFLI_EPIC_DRAW_THREAD
+    /**
+    * Render thread callback.
+    * @param ptr Pointer to draw unit
+    */
+    static void _epic_render_thread_cb(void * ptr);
+#endif
+
+/**
+ * Execute drawing operation.
+ * @param u EPIC draw unit
+ */
+static void _epic_execute_drawing(lv_draw_sifli_epic_unit_t * u);
+
+static lv_layer_t * _epic_get_task_layer(const lv_draw_task_t * task);
+
+/**********************
+ *  STATIC VARIABLES
+ **********************/
+
+static bool epic_draw_unit_initialized = false;
+/**********************
+ *      MACROS
+ **********************/
+
+/* Vector glyphs are not handled by the EPIC label path below.
+ * Keep the check lightweight and fall back only when the first glyph is vector. */
+static bool _epic_label_has_vector_glyph(const lv_draw_label_dsc_t * draw_dsc)
+{
+#if LV_USE_FREETYPE && LV_USE_VECTOR_GRAPHIC && LV_USE_THORVG
+    if(draw_dsc == NULL || draw_dsc->font == NULL || draw_dsc->text == NULL || draw_dsc->text[0] == '\0') {
+        return false;
+    }
+
+    lv_font_glyph_dsc_t glyph_dsc;
+    uint32_t txt_ofs = 0;
+    uint32_t letter = lv_text_encoded_next(draw_dsc->text, &txt_ofs);
+
+    if(letter == '\0') {
+        return false;
+    }
+
+    if(lv_font_get_glyph_dsc(draw_dsc->font, &glyph_dsc, letter, '\0') &&
+       glyph_dsc.format == LV_FONT_GLYPH_FORMAT_VECTOR) {
+        return true;
+    }
+#else
+    LV_UNUSED(draw_dsc);
+#endif
+
+    return false;
+}
+
+/**********************
+ *   GLOBAL FUNCTIONS
+ **********************/
+
+void lv_draw_sifli_epic_init(void)
+{
+    if(epic_draw_unit_initialized) {
+        return;
+    }
+
+    /* Initialize EPIC hardware */
+    lv_epic_init();
+    if(!lv_epic_is_initialized()) {
+        LV_LOG_WARN("SiFli EPIC initialization failed");
+        return;
+    }
+
+    /* Initialize draw buffer handlers */
+    lv_draw_buf_sifli_epic_init_handlers();
+
+    /* Create EPIC draw unit */
+    lv_draw_sifli_epic_unit_t * draw_epic_unit = lv_draw_create_unit(sizeof(lv_draw_sifli_epic_unit_t));
+    draw_epic_unit->base_unit.evaluate_cb = _epic_evaluate;
+    draw_epic_unit->base_unit.dispatch_cb = _epic_dispatch;
+    draw_epic_unit->base_unit.delete_cb = _epic_delete;
+    draw_epic_unit->base_unit.name = "SiFli_EPIC";
+
+#if LV_USE_SIFLI_EPIC_DRAW_THREAD
+    lv_thread_init(&draw_epic_unit->thread, LV_THREAD_PRIO_HIGH,
+                   _epic_render_thread_cb, LV_DRAW_THREAD_STACKSIZE, draw_epic_unit);
+#endif
+
+    epic_draw_unit_initialized = true;
+}
+
+void lv_draw_sifli_epic_deinit(void)
+{
+    if(!epic_draw_unit_initialized) {
+        return;
+    }
+
+    lv_epic_deinit();
+    epic_draw_unit_initialized = false;
+}
+
+/**********************
+ *   STATIC FUNCTIONS
+ **********************/
+
+static lv_layer_t * _epic_get_task_layer(const lv_draw_task_t * task)
+{
+    if(task == NULL || task->draw_dsc == NULL) {
+        return NULL;
+    }
+
+    const lv_draw_dsc_base_t * draw_dsc_base = (const lv_draw_dsc_base_t *)task->draw_dsc;
+    return draw_dsc_base->layer;
+}
+
+static int32_t _epic_evaluate(lv_draw_unit_t * draw_unit, lv_draw_task_t * task)
+{
+    LV_UNUSED(draw_unit);
+
+    lv_layer_t * target_layer;
+
+    if(task == NULL) {
+        return 0;
+    }
+
+    target_layer = _epic_get_task_layer(task);
+    if(target_layer == NULL) {
+        return 0;
+    }
+
+    if(!lv_epic_cf_supported(target_layer->color_format, 0)) {
+        return 0;
+    }
+
+    switch(task->type) {
+        case LV_DRAW_TASK_TYPE_FILL: {
+                const lv_draw_fill_dsc_t * draw_dsc = (const lv_draw_fill_dsc_t *)task->draw_dsc;
+
+                if(target_layer == NULL) {
+                    return 0;
+                }
+
+                /* EPIC doesn't support rounded corners */
+                if(draw_dsc->radius != 0) {
+                    return 0;
+                }
+
+                /* Check gradient support */
+                if(draw_dsc->grad.dir != LV_GRAD_DIR_NONE) {
+                    if(draw_dsc->grad.dir != LV_GRAD_DIR_HOR && draw_dsc->grad.dir != LV_GRAD_DIR_VER) {
+                        return 0;
+                    }
+
+                    /* Only support 2-stop gradients */
+                    if(draw_dsc->grad.stops_count != 2) {
+                        return 0;
+                    }
+
+                    /* Check if output format supports gradient */
+                    lv_color_format_t dest_cf = target_layer->color_format;
+                    uint32_t epic_cf = lv_img_cf_to_epic_cf(dest_cf);
+                    if(!EPIC_SUPPROT_OUT_FORMAT(epic_cf)) {
+                        return 0;
+                    }
+                }
+
+                if(task->preference_score > 70) {
+                    task->preference_score = 70;
+                    task->preferred_draw_unit_id = DRAW_UNIT_ID_SIFLI_EPIC;
+                }
+                return 1;
+            }
+
+        case LV_DRAW_TASK_TYPE_IMAGE: {
+                const lv_draw_image_dsc_t * draw_dsc = (const lv_draw_image_dsc_t *)task->draw_dsc;
+                bool has_transform = (draw_dsc->rotation != 0 ||
+                                      draw_dsc->scale_x != LV_SCALE_NONE ||
+                                      draw_dsc->scale_y != LV_SCALE_NONE);
+
+                if(draw_dsc->src == NULL) {
+                    return 0;
+                }
+
+                if(draw_dsc->clip_radius != 0) {
+                    return 0;
+                }
+
+                if(draw_dsc->blend_mode != LV_BLEND_MODE_NORMAL) {
+                    return 0;
+                }
+
+                /* Check if recolor is used */
+                bool has_recolor = (draw_dsc->recolor_opa != LV_OPA_TRANSP);
+                if(has_recolor) {
+                    return 0;
+                }
+
+                /* Check color format support */
+                if(!lv_epic_cf_supported(draw_dsc->header.cf, draw_dsc->header.flags)) {
+                    return 0;
+                }
+
+                /* SF32LB52 cannot transform its A8 mask layer.  The image path
+                 * stages immutable variable images as interleaved ARGB8565. */
+                if((LV_COLOR_FORMAT_RGB565A8 == draw_dsc->header.cf) && has_transform) {
+#ifdef CONFIG_LV_USE_SIFLI_EPIC_IMAGE_SRAM_STAGE
+                    if(lv_image_src_get_type(draw_dsc->src) != LV_IMAGE_SRC_VARIABLE) {
+                        return 0;
+                    }
+
+                    const lv_image_dsc_t * src_dsc = (const lv_image_dsc_t *)draw_dsc->src;
+                    if(src_dsc->data == NULL ||
+                       (src_dsc->header.flags & LV_IMAGE_FLAGS_MODIFIABLE) != 0U) {
+                        return 0;
+                    }
+#else
+                    return 0;
+#endif
+                }
+
+                if(task->preference_score > 80) {
+                    task->preference_score = 80;
+                    task->preferred_draw_unit_id = DRAW_UNIT_ID_SIFLI_EPIC;
+                }
+                return 1;
+            }
+
+        case LV_DRAW_TASK_TYPE_BORDER: {
+                const lv_draw_border_dsc_t * draw_dsc = (const lv_draw_border_dsc_t *)task->draw_dsc;
+
+                if(draw_dsc->radius != 0) {
+                    return 0;
+                }
+
+                if(task->preference_score > 90) {
+                    task->preference_score = 90;
+                    task->preferred_draw_unit_id = DRAW_UNIT_ID_SIFLI_EPIC;
+                }
+                return 1;
+            }
+
+#ifdef EPIC_SUPPORT_A8
+        case LV_DRAW_TASK_TYPE_LABEL: {
+                const lv_draw_label_dsc_t * draw_dsc = (const lv_draw_label_dsc_t *)task->draw_dsc;
+                lv_layer_t * target_layer = _epic_get_task_layer(task);
+
+                if(target_layer == NULL) {
+                    return 0;
+                }
+
+                if(draw_dsc->font == NULL || draw_dsc->text == NULL || draw_dsc->text[0] == '\0') {
+                    return 0;
+                }
+
+                if(_epic_label_has_vector_glyph(draw_dsc)) {
+                    return 0;
+                }
+
+                if(!lv_epic_cf_supported(target_layer->color_format, 0)) {
+                    return 0;
+                }
+
+                if(task->preference_score > 95) {
+                    task->preference_score = 95;
+                    task->preferred_draw_unit_id = DRAW_UNIT_ID_SIFLI_EPIC;
+                }
+                return 1;
+            }
+#endif
+
+        case LV_DRAW_TASK_TYPE_LAYER: {
+                const lv_draw_image_dsc_t * draw_dsc = (const lv_draw_image_dsc_t *)task->draw_dsc;
+                lv_layer_t * layer_to_draw = (lv_layer_t *)draw_dsc->src;
+
+                if(layer_to_draw == NULL) {
+                    return 0;
+                }
+
+                if(layer_to_draw->draw_buf == NULL) {
+                    return 0;
+                }
+
+                /* Check if recolor is used */
+                bool has_recolor = (draw_dsc->recolor_opa != LV_OPA_TRANSP);
+                if(has_recolor) {
+                    return 0;
+                }
+
+                /* Check if transform is used */
+                bool has_transform = (draw_dsc->rotation != 0 ||
+                                      draw_dsc->scale_x != LV_SCALE_NONE ||
+                                      draw_dsc->scale_y != LV_SCALE_NONE);
+
+                /* Check color format support */
+                if(!lv_epic_cf_supported(layer_to_draw->color_format, 0)) {
+                    return 0;
+                }
+
+                /* RGB565A8 with transform is not supported */
+                if((LV_COLOR_FORMAT_RGB565A8 == layer_to_draw->color_format) && has_transform) {
+                    return 0;
+                }
+
+                if(task->preference_score > 80) {
+                    task->preference_score = 80;
+                    task->preferred_draw_unit_id = DRAW_UNIT_ID_SIFLI_EPIC;
+                }
+                return 1;
+            }
+
+        default:
+            return 0;
+    }
+
+    return 0;
+}
+
+static int32_t _epic_dispatch(lv_draw_unit_t * draw_unit, lv_layer_t * layer)
+{
+    lv_draw_sifli_epic_unit_t * draw_epic_unit = (lv_draw_sifli_epic_unit_t *)draw_unit;
+
+    /* Try to get a ready to draw task */
+    lv_draw_task_t * task = lv_draw_get_next_available_task(layer, NULL, DRAW_UNIT_ID_SIFLI_EPIC);
+
+    if(task == NULL) {
+
+        return -1;
+    }
+
+    /* Return immediately if EPIC is busy */
+    if(draw_epic_unit->task_act) {
+
+        return 0;
+    }
+
+    /* Let the SW unit draw this task if not preferred for EPIC */
+    if(task->preferred_draw_unit_id != DRAW_UNIT_ID_SIFLI_EPIC) {
+
+        return -1;
+    }
+
+    /* Allocate buffer for layer */
+    if(lv_draw_layer_alloc_buf(layer) == NULL) {
+        EPIC_ASSERT_MSG(false, "EPIC: Failed to allocate layer draw buffer");
+
+        return -1;
+    }
+
+    /* Mark task as in progress */
+    task->state = LV_DRAW_TASK_STATE_IN_PROGRESS;
+    draw_epic_unit->base_unit.target_layer = layer;
+    draw_epic_unit->base_unit.clip_area = &task->clip_area;
+
+
+#if LV_USE_SIFLI_EPIC_DRAW_THREAD
+
+    draw_epic_unit->task_act = task;
+    /* Let the render thread work */
+    if(draw_epic_unit->inited) {
+        lv_thread_sync_signal(&draw_epic_unit->sync);
+    }
+#else
+    draw_epic_unit->task_act = task;
+    /* Execute drawing immediately */
+    _epic_execute_drawing(draw_epic_unit);
+
+    draw_epic_unit->task_act->state = LV_DRAW_TASK_STATE_READY;
+    draw_epic_unit->task_act = NULL;
+
+    /* Request new dispatching */
+    lv_draw_dispatch_request();
+#endif
+
+    return 1;
+}
+
+static int32_t _epic_delete(lv_draw_unit_t * draw_unit)
+{
+#if LV_USE_SIFLI_EPIC_DRAW_THREAD
+    lv_draw_sifli_epic_unit_t * draw_epic_unit = (lv_draw_sifli_epic_unit_t *)draw_unit;
+
+    draw_epic_unit->exit_status = true;
+
+    if(draw_epic_unit->inited) {
+        lv_thread_sync_signal(&draw_epic_unit->sync);
+    }
+
+    return lv_thread_delete(&draw_epic_unit->thread);
+#else
+    LV_UNUSED(draw_unit);
+    return 0;
+#endif
+}
+
+static void _epic_execute_drawing(lv_draw_sifli_epic_unit_t * u)
+{
+    lv_draw_task_t * task = u->task_act;
+    lv_layer_t * layer = ((lv_draw_unit_t *)u)->target_layer;
+
+    if(layer && layer->draw_buf) {
+        lv_area_t draw_area;
+
+        if(_lv_area_intersect(&draw_area, &task->_real_area, &task->clip_area)) {
+            lv_area_move(&draw_area, -layer->buf_area.x1, -layer->buf_area.y1);
+            lv_draw_buf_flush_cache(layer->draw_buf, &draw_area);
+        }
+    }
+
+    /* Execute based on task type */
+    switch(task->type) {
+        case LV_DRAW_TASK_TYPE_BORDER:
+            lv_draw_sifli_epic_border(task);
+            break;
+
+        case LV_DRAW_TASK_TYPE_LABEL:
+            lv_draw_sifli_epic_label(task);
+            break;
+
+        case LV_DRAW_TASK_TYPE_FILL:
+            lv_draw_sifli_epic_fill(task);
+            break;
+
+        case LV_DRAW_TASK_TYPE_IMAGE:
+            lv_draw_sifli_epic_img(task);
+            break;
+
+        case LV_DRAW_TASK_TYPE_LAYER:
+            lv_draw_sifli_epic_layer(task);
+            break;
+
+        default:
+            break;
+    }
+
+    if(layer && layer->draw_buf) {
+        lv_area_t draw_area;
+
+        if(_lv_area_intersect(&draw_area, &task->_real_area, &task->clip_area)) {
+            lv_area_move(&draw_area, -layer->buf_area.x1, -layer->buf_area.y1);
+            lv_draw_buf_invalidate_cache(layer->draw_buf, &draw_area);
+        }
+    }
+
+}
+
+#if LV_USE_SIFLI_EPIC_DRAW_THREAD
+static void _epic_render_thread_cb(void * ptr)
+{
+    lv_draw_sifli_epic_unit_t * u = ptr;
+
+    lv_thread_sync_init(&u->sync);
+    u->inited = true;
+
+    while(1) {
+        /* Wait for sync if there is no task set */
+        while(u->task_act == NULL) {
+            if(u->exit_status) {
+                break;
+            }
+            lv_thread_sync_wait(&u->sync);
+        }
+
+        if(u->exit_status) {
+            break;
+        }
+
+        _epic_execute_drawing(u);
+
+        /* Signal the ready state to dispatcher */
+        u->task_act->state = LV_DRAW_TASK_STATE_READY;
+
+        /* Cleanup */
+        u->task_act = NULL;
+
+        /* Request new dispatching */
+        lv_draw_dispatch_request();
+    }
+
+    u->inited = false;
+    lv_thread_sync_delete(&u->sync);
+}
+#endif
+
+#endif /*LV_USE_SIFLI_EPIC*/

--- a/src/draw/sifli/epic/lv_draw_sifli_epic.h
+++ b/src/draw/sifli/epic/lv_draw_sifli_epic.h
@@ -1,0 +1,114 @@
+/**
+ * @file lv_draw_sifli_epic.h
+ *
+ */
+
+/**
+ * Copyright 2024 SiFli Technologies
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#ifndef LV_DRAW_SIFLI_EPIC_H
+#define LV_DRAW_SIFLI_EPIC_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*********************
+ *      INCLUDES
+ *********************/
+
+#include "../../../lv_conf_internal.h"
+
+#if LV_USE_SIFLI_EPIC
+#include "../../sw/lv_draw_sw.h"
+#include "../../../display/lv_display_private.h"
+
+/*********************
+ *      DEFINES
+ *********************/
+
+/**********************
+ *      TYPEDEFS
+ **********************/
+
+/**
+ * SiFli EPIC draw unit structure.
+ * Similar to NXP PXP's lv_draw_pxp_unit_t.
+ */
+typedef struct _lv_draw_sifli_epic_unit_t {
+    lv_draw_unit_t base_unit;       /**< Base draw unit */
+    lv_draw_task_t * task_act;      /**< Currently active task */
+
+#if LV_USE_SIFLI_EPIC_DRAW_THREAD
+    lv_thread_sync_t sync;          /**< Thread synchronization primitive */
+    lv_thread_t thread;             /**< Render thread */
+    volatile bool inited;           /**< Initialization status */
+    volatile bool exit_status;      /**< Exit status for thread */
+#endif
+} lv_draw_sifli_epic_unit_t;
+
+/**********************
+ * GLOBAL PROTOTYPES
+ **********************/
+
+/**
+ * Initialize SiFli EPIC draw unit.
+ * This function should be called during display initialization.
+ */
+void lv_draw_sifli_epic_init(void);
+
+/**
+ * Deinitialize SiFli EPIC draw unit.
+ * This function should be called during display deinitialization.
+ */
+void lv_draw_sifli_epic_deinit(void);
+
+/**
+ * Initialize draw buffer handlers for EPIC.
+ */
+void lv_draw_buf_sifli_epic_init_handlers(void);
+
+/**
+ * EPIC fill operation.
+ * @param t Draw task
+ */
+void lv_draw_sifli_epic_fill(lv_draw_task_t * t);
+
+/**
+ * EPIC border draw operation.
+ * @param t Draw task
+ */
+void lv_draw_sifli_epic_border(lv_draw_task_t * t);
+
+/**
+ * EPIC label draw operation.
+ * @param t Draw task
+ */
+void lv_draw_sifli_epic_label(lv_draw_task_t * t);
+
+/**
+ * EPIC image draw operation.
+ * @param t Draw task
+ */
+void lv_draw_sifli_epic_img(lv_draw_task_t * t);
+
+/**
+ * EPIC layer blend operation.
+ * @param t Draw task
+ */
+void lv_draw_sifli_epic_layer(lv_draw_task_t * t);
+
+/**********************
+ *      MACROS
+ **********************/
+
+#endif /*LV_USE_SIFLI_EPIC*/
+
+#ifdef __cplusplus
+} /*extern "C"*/
+#endif
+
+#endif /*LV_DRAW_SIFLI_EPIC_H*/

--- a/src/draw/sifli/epic/lv_draw_sifli_epic_border.c
+++ b/src/draw/sifli/epic/lv_draw_sifli_epic_border.c
@@ -1,0 +1,135 @@
+/**
+ * @file lv_draw_sifli_epic_border.c
+ *
+ */
+
+/**
+ * Copyright 2024 SiFli Technologies
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+/*********************
+ *      INCLUDES
+ *********************/
+
+#include "lv_draw_sifli_epic.h"
+
+#if LV_USE_SIFLI_EPIC
+#include "../../../misc/lv_area.h"
+
+/*********************
+ *      DEFINES
+ *********************/
+
+/**********************
+ *      TYPEDEFS
+ **********************/
+
+/**********************
+ *  STATIC PROTOTYPES
+ **********************/
+
+static void draw_border_simple(lv_draw_task_t * task, const lv_area_t * outer_area, const lv_area_t * inner_area,
+                               const lv_draw_border_dsc_t * dsc);
+static void draw_fill_part(lv_draw_task_t * task, const lv_area_t * area, const lv_draw_border_dsc_t * dsc);
+
+/**********************
+ *  STATIC VARIABLES
+ **********************/
+
+/**********************
+ *      MACROS
+ **********************/
+
+/**********************
+ *   GLOBAL FUNCTIONS
+ **********************/
+
+void lv_draw_sifli_epic_border(lv_draw_task_t * task)
+{
+    const lv_draw_border_dsc_t * dsc = (const lv_draw_border_dsc_t *)task->draw_dsc;
+    const lv_area_t * coords = &task->area;
+
+    if(dsc->opa <= LV_OPA_MIN) return;
+    if(dsc->width == 0) return;
+    if(dsc->side == LV_BORDER_SIDE_NONE) return;
+
+    if(dsc->radius != 0) {
+        return;
+    }
+
+    lv_area_t area_inner;
+    lv_area_copy(&area_inner, coords);
+    area_inner.x1 += ((dsc->side & LV_BORDER_SIDE_LEFT) ? dsc->width : -dsc->width);
+    area_inner.x2 -= ((dsc->side & LV_BORDER_SIDE_RIGHT) ? dsc->width : -dsc->width);
+    area_inner.y1 += ((dsc->side & LV_BORDER_SIDE_TOP) ? dsc->width : -dsc->width);
+    area_inner.y2 -= ((dsc->side & LV_BORDER_SIDE_BOTTOM) ? dsc->width : -dsc->width);
+
+    draw_border_simple(task, coords, &area_inner, dsc);
+}
+
+/**********************
+ *   STATIC FUNCTIONS
+ **********************/
+
+static void draw_border_simple(lv_draw_task_t * task, const lv_area_t * outer_area, const lv_area_t * inner_area,
+                               const lv_draw_border_dsc_t * dsc)
+{
+    lv_area_t area;
+
+    bool top_side = outer_area->y1 <= inner_area->y1;
+    bool bottom_side = outer_area->y2 >= inner_area->y2;
+    bool left_side = outer_area->x1 <= inner_area->x1;
+    bool right_side = outer_area->x2 >= inner_area->x2;
+
+    /* Top */
+    area.x1 = outer_area->x1;
+    area.x2 = outer_area->x2;
+    area.y1 = outer_area->y1;
+    area.y2 = inner_area->y1 - 1;
+    if(top_side && area.y1 <= area.y2) {
+        draw_fill_part(task, &area, dsc);
+    }
+
+    /* Bottom */
+    area.y1 = inner_area->y2 + 1;
+    area.y2 = outer_area->y2;
+    if(bottom_side && area.y1 <= area.y2) {
+        draw_fill_part(task, &area, dsc);
+    }
+
+    /* Left */
+    area.x1 = outer_area->x1;
+    area.x2 = inner_area->x1 - 1;
+    area.y1 = top_side ? inner_area->y1 : outer_area->y1;
+    area.y2 = bottom_side ? inner_area->y2 : outer_area->y2;
+    if(left_side && area.x1 <= area.x2 && area.y1 <= area.y2) {
+        draw_fill_part(task, &area, dsc);
+    }
+
+    /* Right */
+    area.x1 = inner_area->x2 + 1;
+    area.x2 = outer_area->x2;
+    if(right_side && area.x1 <= area.x2 && area.y1 <= area.y2) {
+        draw_fill_part(task, &area, dsc);
+    }
+}
+
+static void draw_fill_part(lv_draw_task_t * task, const lv_area_t * area, const lv_draw_border_dsc_t * dsc)
+{
+    lv_draw_fill_dsc_t fill_dsc;
+    lv_draw_fill_dsc_init(&fill_dsc);
+    fill_dsc.color = dsc->color;
+    fill_dsc.opa = dsc->opa;
+
+    const lv_draw_dsc_base_t * draw_dsc_base = (const lv_draw_dsc_base_t *)task->draw_dsc;
+    fill_dsc.base.layer = draw_dsc_base->layer;
+
+    lv_draw_task_t fill_task = *task;
+    fill_task.draw_dsc = &fill_dsc;
+    fill_task.area = *area;
+    lv_draw_sifli_epic_fill(&fill_task);
+}
+
+#endif /*LV_USE_SIFLI_EPIC*/

--- a/src/draw/sifli/epic/lv_draw_sifli_epic_fill.c
+++ b/src/draw/sifli/epic/lv_draw_sifli_epic_fill.c
@@ -1,0 +1,157 @@
+/**
+ * @file lv_draw_sifli_epic_fill.c
+ *
+ */
+
+/**
+ * Copyright 2024 SiFli Technologies
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+/*********************
+ *      INCLUDES
+ *********************/
+
+#include "lv_draw_sifli_epic.h"
+
+#if LV_USE_SIFLI_EPIC
+#include "lv_sifli_epic_utils.h"
+#include "../../../misc/lv_area.h"
+
+/*********************
+ *      DEFINES
+ *********************/
+
+/**********************
+ *      TYPEDEFS
+ **********************/
+
+/**********************
+ *  STATIC PROTOTYPES
+ **********************/
+
+/**********************
+ *  STATIC VARIABLES
+ **********************/
+
+/**********************
+ *      MACROS
+ **********************/
+
+/**********************
+ *   GLOBAL FUNCTIONS
+ **********************/
+
+void lv_draw_sifli_epic_fill(lv_draw_task_t * task)
+{
+    const lv_draw_fill_dsc_t * dsc = (const lv_draw_fill_dsc_t *)task->draw_dsc;
+    const lv_area_t * coords = &task->area;
+
+    if(dsc->opa <= LV_OPA_MIN) {
+        return;
+    }
+
+    const lv_draw_dsc_base_t * draw_dsc_base = (const lv_draw_dsc_base_t *)task->draw_dsc;
+    lv_layer_t * layer = draw_dsc_base->layer;
+
+    if(layer == NULL) {
+        return;
+    }
+
+    lv_area_t blend_area;
+    if(!_lv_area_intersect(&blend_area, coords, &task->clip_area)) {
+        return; /* Fully clipped */
+    }
+
+    if(!_lv_area_intersect(&blend_area, &blend_area, &layer->buf_area)) {
+        return; /* Fully clipped */
+    }
+
+    lv_grad_dir_t grad_dir = dsc->grad.dir;
+    if(grad_dir == LV_GRAD_DIR_NONE) {
+        /* Solid color fill */
+        EPIC_LayerConfigTypeDef input_layers[1];
+        EPIC_LayerConfigTypeDef output_canvas;
+
+        if(lv_epic_setup_layers(&input_layers[0], &output_canvas, task, coords)) {
+            return; /* Fully clipped */
+        }
+
+        /* Set fill color */
+        output_canvas.color_r = dsc->color.red;
+        output_canvas.color_g = dsc->color.green;
+        output_canvas.color_b = dsc->color.blue;
+        output_canvas.color_en = true;
+        if(dsc->opa < LV_OPA_MAX) {
+            /* Alpha blending with background */
+            input_layers[0].alpha = (dsc->opa == 0) ? 255 : (256 - dsc->opa);
+            (void)lv_epic_fill(input_layers, 1, &output_canvas);
+        }
+        else {
+            /* Opaque fill */
+            (void)lv_epic_fill(NULL, 0, &output_canvas);
+        }
+    }
+    else {
+        /* Gradient fill */
+        lv_color_format_t dest_cf = layer->color_format;
+        uint32_t epic_cf = lv_img_cf_to_epic_cf(dest_cf);
+
+        LV_ASSERT_MSG(EPIC_SUPPROT_OUT_FORMAT(epic_cf),
+                      "EPIC: Color format not supported for gradient fill");
+
+        uint8_t * dest_buf = lv_draw_layer_go_to_xy(layer,
+                                                    blend_area.x1 - layer->buf_area.x1,
+                                                    blend_area.y1 - layer->buf_area.y1);
+
+        EPIC_GradCfgTypeDef param;
+        HAL_EPIC_FillGradDataInit(&param);
+
+        param.start = dest_buf;
+        param.color_mode = epic_cf;
+        param.width = lv_area_get_width(&blend_area);
+        param.height = lv_area_get_height(&blend_area);
+        param.total_width = layer->draw_buf ? lv_epic_stride_to_width(layer->draw_buf->header.stride,
+                                                                      dest_cf) : lv_area_get_width(&layer->buf_area);
+        /* Setup gradient colors */
+        if(grad_dir == LV_GRAD_DIR_VER) {
+            /* Vertical gradient */
+            LV_ASSERT(dsc->grad.stops_count == 2);
+            EPIC_ColorDef color1 = lv_color_to_epic_color(
+                                       dsc->grad.stops[0].color,
+                                       LV_OPA_MIX2(dsc->grad.stops[0].opa, dsc->opa));
+            EPIC_ColorDef color2 = lv_color_to_epic_color(
+                                       dsc->grad.stops[1].color,
+                                       LV_OPA_MIX2(dsc->grad.stops[1].opa, dsc->opa));
+
+            param.color[0][0] = color1;
+            param.color[0][1] = color1;
+            param.color[1][0] = color2;
+            param.color[1][1] = color2;
+        }
+        else if(grad_dir == LV_GRAD_DIR_HOR) {
+            /* Horizontal gradient */
+            LV_ASSERT(dsc->grad.stops_count == 2);
+            EPIC_ColorDef color1 = lv_color_to_epic_color(
+                                       dsc->grad.stops[0].color,
+                                       LV_OPA_MIX2(dsc->grad.stops[0].opa, dsc->opa));
+            EPIC_ColorDef color2 = lv_color_to_epic_color(
+                                       dsc->grad.stops[1].color,
+                                       LV_OPA_MIX2(dsc->grad.stops[1].opa, dsc->opa));
+
+            param.color[0][0] = color1;
+            param.color[0][1] = color2;
+            param.color[1][0] = color1;
+            param.color[1][1] = color2;
+        }
+
+        (void)lv_epic_fill_grad(&param);
+    }
+}
+
+/**********************
+ *   STATIC FUNCTIONS
+ **********************/
+
+#endif /*LV_USE_SIFLI_EPIC*/

--- a/src/draw/sifli/epic/lv_draw_sifli_epic_img.c
+++ b/src/draw/sifli/epic/lv_draw_sifli_epic_img.c
@@ -1,0 +1,390 @@
+/**
+ * @file lv_draw_sifli_epic_img.c
+ *
+ */
+
+/**
+ * Copyright 2024 SiFli Technologies
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+/*********************
+ *      INCLUDES
+ *********************/
+
+#include "lv_draw_sifli_epic.h"
+
+#if LV_USE_SIFLI_EPIC
+#include <string.h>
+
+#include "lv_sifli_epic_utils.h"
+#include "../../../draw/lv_draw_image.h"
+#include "../../../draw/lv_image_decoder.h"
+#include "../../../misc/lv_area.h"
+
+
+/*********************
+ *      DEFINES
+ *********************/
+
+#define IMAGE_STAGE_CAPACITY            (100U * 100U * 3U)
+#define IMAGE_STAGE_REPLACE_INTERVAL_MS 500U
+
+static void epic_img_draw_core(lv_draw_unit_t * draw_unit, const lv_draw_image_dsc_t * draw_dsc,
+                               const lv_image_decoder_dsc_t * decoder_dsc, lv_draw_image_sup_t * sup,
+                               const lv_area_t * img_coords, const lv_area_t * clipped_img_area);
+
+#ifdef CONFIG_LV_USE_SIFLI_EPIC_IMAGE_SRAM_STAGE
+
+/**********************
+ *      TYPEDEFS
+ **********************/
+
+/**********************
+ *  STATIC PROTOTYPES
+ **********************/
+
+static const lv_image_dsc_t * stage_immutable_image(const lv_image_dsc_t * src_dsc);
+
+/**********************
+ *  STATIC VARIABLES
+ **********************/
+
+static struct {
+    const uint8_t * src;
+    uint32_t src_size;
+    uint32_t src_stride;
+    lv_color_format_t src_cf;
+    uint32_t loaded_at;
+    lv_image_dsc_t dsc;
+} image_stage;
+
+static LV_ATTRIBUTE_MEM_ALIGN uint8_t image_stage_data[IMAGE_STAGE_CAPACITY];
+
+#endif
+
+/**********************
+ *   GLOBAL FUNCTIONS
+ **********************/
+
+void lv_draw_sifli_epic_img(lv_draw_task_t * task)
+{
+    const lv_draw_image_dsc_t * dsc = (const lv_draw_image_dsc_t *)task->draw_dsc;
+    const lv_area_t * coords = &task->area;
+    const lv_draw_dsc_base_t * draw_dsc_base = (const lv_draw_dsc_base_t *)task->draw_dsc;
+    lv_layer_t * layer = draw_dsc_base->layer;
+
+    if(dsc->opa <= LV_OPA_MIN) {
+        return;
+    }
+
+    if(layer == NULL) {
+        return;
+    }
+
+    lv_draw_unit_t draw_unit = {0};
+    draw_unit.target_layer = layer;
+    draw_unit.clip_area = &task->clip_area;
+
+    lv_draw_image_dsc_t local_dsc = *dsc;
+    local_dsc.base.layer = layer;
+
+    bool has_transform = dsc->rotation != 0 || dsc->scale_x != LV_SCALE_NONE || dsc->scale_y != LV_SCALE_NONE;
+    const lv_image_dsc_t * staged = NULL;
+
+    if(dsc->header.cf == LV_COLOR_FORMAT_RGB565 || dsc->header.cf == LV_COLOR_FORMAT_RGB565A8) {
+#ifdef CONFIG_LV_USE_SIFLI_EPIC_IMAGE_SRAM_STAGE
+        if(lv_image_src_get_type(dsc->src) == LV_IMAGE_SRC_VARIABLE) {
+            staged = stage_immutable_image((const lv_image_dsc_t *)dsc->src);
+        }
+#endif
+
+        if(staged != NULL) {
+            local_dsc.src = staged;
+            local_dsc.header = staged->header;
+        }
+        else if(dsc->header.cf == LV_COLOR_FORMAT_RGB565A8 && has_transform) {
+            lv_draw_sw_image(&draw_unit, &local_dsc, coords);
+            return;
+        }
+    }
+
+    if(dsc->tile) {
+        _lv_draw_image_tiled_helper(&draw_unit, &local_dsc, coords, epic_img_draw_core);
+    }
+    else {
+        _lv_draw_image_normal_helper(&draw_unit, &local_dsc, coords, epic_img_draw_core);
+    }
+}
+
+/**********************
+ *   STATIC FUNCTIONS
+ **********************/
+
+#ifdef CONFIG_LV_USE_SIFLI_EPIC_IMAGE_SRAM_STAGE
+static const lv_image_dsc_t * stage_immutable_image(const lv_image_dsc_t * src_dsc)
+{
+    if(src_dsc == NULL || src_dsc->data == NULL ||
+       (src_dsc->header.cf != LV_COLOR_FORMAT_RGB565 &&
+        src_dsc->header.cf != LV_COLOR_FORMAT_RGB565A8) ||
+       (src_dsc->header.flags & LV_IMAGE_FLAGS_MODIFIABLE) != 0U) {
+        return NULL;
+    }
+
+    uint32_t width = src_dsc->header.w;
+    uint32_t height = src_dsc->header.h;
+    uint32_t src_stride = src_dsc->header.stride;
+    uint32_t staged_stride = width * 2U;
+    uint32_t staged_size = staged_stride * height;
+    uint32_t source_size = src_stride * height;
+    lv_color_format_t staged_cf = LV_COLOR_FORMAT_RGB565;
+
+    if(src_dsc->header.cf == LV_COLOR_FORMAT_RGB565A8) {
+        if((src_stride & 1U) != 0U) {
+            return NULL;
+        }
+
+        uint32_t alpha_stride = src_stride / 2U;
+        source_size += alpha_stride * height;
+        staged_stride = width * 3U;
+        staged_size = staged_stride * height;
+        staged_cf = LV_COLOR_FORMAT_ARGB8565;
+    }
+
+    if(width == 0U || height == 0U || src_stride < width * 2U ||
+       src_dsc->data_size < source_size) {
+        return NULL;
+    }
+
+    if(image_stage.src == src_dsc->data && image_stage.src_size == src_dsc->data_size &&
+       image_stage.src_stride == src_stride && image_stage.src_cf == src_dsc->header.cf &&
+       image_stage.dsc.header.w == width && image_stage.dsc.header.h == height) {
+        return &image_stage.dsc;
+    }
+
+    if(staged_size > IMAGE_STAGE_CAPACITY) {
+        return NULL;
+    }
+
+    if(image_stage.src != NULL && lv_tick_elaps(image_stage.loaded_at) < IMAGE_STAGE_REPLACE_INTERVAL_MS) {
+        return NULL;
+    }
+
+    if(src_dsc->header.cf == LV_COLOR_FORMAT_RGB565) {
+        for(uint32_t y = 0; y < height; y++) {
+            memcpy(image_stage_data + y * staged_stride,
+                   src_dsc->data + y * src_stride, staged_stride);
+        }
+    }
+    else {
+        uint32_t alpha_stride = src_stride / 2U;
+        const uint8_t * alpha_plane = src_dsc->data + src_stride * height;
+        for(uint32_t y = 0; y < height; y++) {
+            const uint8_t * rgb = src_dsc->data + y * src_stride;
+            const uint8_t * alpha = alpha_plane + y * alpha_stride;
+            uint8_t * dst = image_stage_data + y * staged_stride;
+
+            for(uint32_t x = 0; x < width; x++) {
+                dst[x * 3U] = rgb[x * 2U];
+                dst[x * 3U + 1U] = rgb[x * 2U + 1U];
+                dst[x * 3U + 2U] = alpha[x];
+            }
+        }
+    }
+
+    image_stage.src = src_dsc->data;
+    image_stage.src_size = src_dsc->data_size;
+    image_stage.src_stride = src_stride;
+    image_stage.src_cf = src_dsc->header.cf;
+    image_stage.loaded_at = lv_tick_get();
+    image_stage.dsc = *src_dsc;
+    image_stage.dsc.header.cf = staged_cf;
+    image_stage.dsc.header.stride = staged_stride;
+    image_stage.dsc.header.flags &= ~(LV_IMAGE_FLAGS_ALLOCATED | LV_IMAGE_FLAGS_MODIFIABLE);
+    image_stage.dsc.data = image_stage_data;
+    image_stage.dsc.data_size = staged_size;
+
+    return &image_stage.dsc;
+}
+#endif
+
+static void epic_img_draw_core(lv_draw_unit_t * draw_unit, const lv_draw_image_dsc_t * draw_dsc,
+                               const lv_image_decoder_dsc_t * decoder_dsc, lv_draw_image_sup_t * sup,
+                               const lv_area_t * img_coords, const lv_area_t * clipped_img_area)
+{
+    const lv_draw_buf_t * decoded = decoder_dsc->decoded;
+    const uint8_t * src_buf;
+    lv_color_format_t cf;
+    uint32_t img_total_width;
+    const bool is_ezip = (decoded != NULL) && ((decoded->header.flags & LV_IMAGE_FLAGS_EZIP) != 0U);
+#if defined(EPIC_INPUT_JPEG)
+    const bool is_jpeg = (decoded != NULL) && ((decoded->header.flags & LV_IMAGE_FLAGS_JPEG) != 0U);
+#else
+    const bool is_jpeg = false;
+#endif
+
+    if(decoded == NULL || decoded->data == NULL) {
+        return;
+    }
+
+    if(draw_dsc->clip_radius != 0 || draw_dsc->blend_mode != LV_BLEND_MODE_NORMAL) {
+        return;
+    }
+
+    lv_draw_buf_flush_cache(decoded, NULL);
+
+    src_buf = decoded->data;
+    cf = decoded->header.cf;
+
+    if(is_ezip || is_jpeg) {
+        img_total_width = decoded->header.w;
+    }
+    else {
+        img_total_width = lv_epic_stride_to_width(decoded->header.stride, cf);
+    }
+
+    EPIC_LayerConfigTypeDef input_layers[4];
+    EPIC_LayerConfigTypeDef output_layer;
+    uint8_t input_layer_cnt = 2;
+
+    lv_draw_task_t task;
+    task.draw_dsc = (void *)draw_dsc;
+    task.area = *img_coords;
+    task._real_area = *img_coords;
+    task.clip_area = *draw_unit->clip_area;
+    task.clip_area_original = task.clip_area;
+
+    if(lv_epic_setup_layers(&input_layers[0], &output_layer, &task, clipped_img_area)) {
+        return;
+    }
+
+    HAL_EPIC_LayerConfigInit(&input_layers[1]);
+    input_layers[1].transform_cfg.angle = (draw_dsc->rotation + 3600) % 3600;
+    input_layers[1].transform_cfg.pivot_x = draw_dsc->pivot.x;
+    input_layers[1].transform_cfg.pivot_y = draw_dsc->pivot.y;
+    input_layers[1].transform_cfg.scale_x = LV_SCALE_NONE * EPIC_INPUT_SCALE_NONE / (uint32_t)draw_dsc->scale_x;
+    input_layers[1].transform_cfg.scale_y = LV_SCALE_NONE * EPIC_INPUT_SCALE_NONE / (uint32_t)draw_dsc->scale_y;
+    input_layers[1].alpha = draw_dsc->opa;
+    input_layers[1].x_offset = img_coords->x1;
+    input_layers[1].y_offset = img_coords->y1;
+
+    if(is_ezip) {
+        input_layers[1].color_mode = EPIC_INPUT_EZIP;
+    }
+#if defined(EPIC_INPUT_JPEG)
+    else if(is_jpeg) {
+        input_layers[1].color_mode = EPIC_INPUT_JPEG;
+    }
+#endif
+    else {
+        input_layers[1].color_mode = lv_img_cf_to_epic_cf(cf);
+    }
+
+    input_layers[1].data = (uint8_t *)src_buf;
+    input_layers[1].data_size = decoded->data_size;
+    input_layers[1].width = lv_area_get_width(img_coords);
+    input_layers[1].height = lv_area_get_height(img_coords);
+    input_layers[1].total_width = img_total_width;
+
+#ifdef EPIC_SUPPORT_A8
+    if(input_layers[1].color_mode == EPIC_INPUT_A8) {
+        input_layers[1].color_en = true;
+        input_layers[1].color_r = sup->alpha_color.red;
+        input_layers[1].color_g = sup->alpha_color.green;
+        input_layers[1].color_b = sup->alpha_color.blue;
+        input_layers[1].ax_mode = ALPHA_BLEND_RGBCOLOR;
+    }
+    else
+#endif
+#ifdef EPIC_SUPPORT_L8
+        if(input_layers[1].color_mode == EPIC_INPUT_L8) {
+            input_layers[1].lookup_table = (uint8_t *)decoder_dsc->palette;
+            input_layers[1].color_en = false;
+        }
+        else
+#endif
+        {
+            input_layers[1].color_en = false;
+        }
+
+#ifdef EPIC_SUPPORT_MASK
+    if(cf == LV_COLOR_FORMAT_RGB565A8) {
+        HAL_EPIC_LayerConfigInit(&input_layers[input_layer_cnt]);
+        input_layers[input_layer_cnt].alpha = draw_dsc->opa;
+        input_layers[input_layer_cnt].x_offset = img_coords->x1;
+        input_layers[input_layer_cnt].y_offset = img_coords->y1;
+        input_layers[input_layer_cnt].color_mode = EPIC_INPUT_A8;
+        input_layers[input_layer_cnt].data = ((uint8_t *)src_buf) + decoded->header.h * decoded->header.stride;
+        input_layers[input_layer_cnt].ax_mode = ALPHA_BLEND_OVERWRITE;
+        input_layers[input_layer_cnt].width = lv_area_get_width(img_coords);
+        input_layers[input_layer_cnt].height = lv_area_get_height(img_coords);
+        input_layers[input_layer_cnt].total_width = decoded->header.w;
+        input_layer_cnt++;
+    }
+#endif
+
+    lv_image_decoder_dsc_t mask_decoder_dsc;
+    bool mask_decoder_opened = false;
+
+    if(draw_dsc->bitmap_mask_src != NULL) {
+        lv_area_t mask_area;
+        const lv_image_dsc_t * mask_dsc = draw_dsc->bitmap_mask_src;
+        const lv_area_t * image_area = lv_area_get_width(&draw_dsc->original_area) < 0 ?
+                                       img_coords : &draw_dsc->original_area;
+
+        if(lv_image_src_get_type(mask_dsc) == LV_IMAGE_SRC_VARIABLE &&
+           (mask_dsc->header.cf == LV_COLOR_FORMAT_A8 || mask_dsc->header.cf == LV_COLOR_FORMAT_L8)) {
+            const lv_image_header_t * header = &mask_dsc->header;
+
+            lv_area_set(&mask_area, 0, 0, header->w - 1, header->h - 1);
+            lv_area_align(image_area, &mask_area, LV_ALIGN_CENTER, 0, 0);
+
+            HAL_EPIC_LayerConfigInit(&input_layers[input_layer_cnt]);
+            input_layers[input_layer_cnt].alpha = LV_OPA_COVER;
+            input_layers[input_layer_cnt].x_offset = mask_area.x1;
+            input_layers[input_layer_cnt].y_offset = mask_area.y1;
+            input_layers[input_layer_cnt].color_mode = EPIC_INPUT_A8;
+            input_layers[input_layer_cnt].data = (uint8_t *)mask_dsc->data;
+            input_layers[input_layer_cnt].ax_mode = ALPHA_BLEND_OVERWRITE;
+            input_layers[input_layer_cnt].width = lv_area_get_width(&mask_area);
+            input_layers[input_layer_cnt].height = lv_area_get_height(&mask_area);
+            input_layers[input_layer_cnt].total_width = header->stride;
+            input_layer_cnt++;
+        }
+        else if(lv_image_decoder_open(&mask_decoder_dsc, draw_dsc->bitmap_mask_src, NULL) == LV_RESULT_OK &&
+                mask_decoder_dsc.decoded != NULL) {
+            const lv_draw_buf_t * mask_img = mask_decoder_dsc.decoded;
+            mask_decoder_opened = true;
+
+            if(mask_img->header.cf == LV_COLOR_FORMAT_A8 || mask_img->header.cf == LV_COLOR_FORMAT_L8) {
+                lv_area_set(&mask_area, 0, 0, mask_img->header.w - 1, mask_img->header.h - 1);
+                lv_area_align(image_area, &mask_area, LV_ALIGN_CENTER, 0, 0);
+
+                HAL_EPIC_LayerConfigInit(&input_layers[input_layer_cnt]);
+                input_layers[input_layer_cnt].alpha = LV_OPA_COVER;
+                input_layers[input_layer_cnt].x_offset = mask_area.x1;
+                input_layers[input_layer_cnt].y_offset = mask_area.y1;
+                input_layers[input_layer_cnt].color_mode = EPIC_INPUT_A8;
+                input_layers[input_layer_cnt].data = (uint8_t *)mask_img->data;
+                input_layers[input_layer_cnt].ax_mode = ALPHA_BLEND_OVERWRITE;
+                input_layers[input_layer_cnt].width = lv_area_get_width(&mask_area);
+                input_layers[input_layer_cnt].height = lv_area_get_height(&mask_area);
+                input_layers[input_layer_cnt].total_width = mask_img->header.stride;
+                input_layer_cnt++;
+            }
+            else {
+            }
+        }
+        else {
+        }
+    }
+
+    (void)lv_epic_blend(input_layers, input_layer_cnt, &output_layer);
+
+    if(mask_decoder_opened) {
+        lv_image_decoder_close(&mask_decoder_dsc);
+    }
+}
+
+#endif /*LV_USE_SIFLI_EPIC*/

--- a/src/draw/sifli/epic/lv_draw_sifli_epic_label.c
+++ b/src/draw/sifli/epic/lv_draw_sifli_epic_label.c
@@ -1,0 +1,300 @@
+/**
+ * @file lv_draw_sifli_epic_label.c
+ *
+ */
+
+/**
+ * Copyright 2024 SiFli Technologies
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+/*********************
+ *      INCLUDES
+ *********************/
+
+#include "lv_draw_sifli_epic.h"
+
+#if LV_USE_SIFLI_EPIC
+#include "lv_sifli_epic_utils.h"
+#include "../../../draw/lv_draw_label.h"
+#include "../../../draw/lv_draw_rect.h"
+
+/*********************
+ *      DEFINES
+ *********************/
+
+/**********************
+ *      TYPEDEFS
+ **********************/
+
+typedef struct {
+    lv_draw_unit_t draw_unit;
+    lv_draw_buf_t * glyph_stage[2];
+    uint8_t next_stage;
+} epic_label_ctx_t;
+
+/**********************
+ *  STATIC PROTOTYPES
+ **********************/
+
+static void draw_letter_cb(lv_draw_unit_t * draw_unit, lv_draw_glyph_dsc_t * glyph_draw_dsc,
+                           lv_draw_fill_dsc_t * fill_draw_dsc, const lv_area_t * fill_area);
+static void draw_placeholder_border(lv_draw_unit_t * draw_unit, lv_draw_glyph_dsc_t * glyph_draw_dsc);
+static void draw_bitmap_glyph(lv_draw_unit_t * draw_unit, lv_draw_glyph_dsc_t * glyph_draw_dsc);
+static void draw_glyph_as_image(lv_draw_unit_t * draw_unit, lv_draw_glyph_dsc_t * glyph_draw_dsc);
+static void draw_fill_part(lv_draw_unit_t * draw_unit, lv_draw_fill_dsc_t * fill_draw_dsc, const lv_area_t * fill_area);
+static bool create_task_from_draw_unit(lv_draw_unit_t * draw_unit, lv_draw_task_t * task, void * draw_dsc,
+                                       const lv_area_t * area);
+static lv_draw_buf_t * stage_glyph_bitmap(epic_label_ctx_t * ctx, const lv_draw_buf_t * glyph_buf);
+
+/**********************
+ *   GLOBAL FUNCTIONS
+ **********************/
+
+void lv_draw_sifli_epic_label(lv_draw_task_t * task)
+{
+    const lv_draw_label_dsc_t * dsc = (const lv_draw_label_dsc_t *)task->draw_dsc;
+
+    if(dsc->opa <= LV_OPA_MIN || dsc->text == NULL || dsc->text[0] == '\0') {
+        return;
+    }
+
+#ifndef EPIC_SUPPORT_A8
+    LV_UNUSED(task);
+#else
+    const lv_draw_dsc_base_t * draw_dsc_base = (const lv_draw_dsc_base_t *)task->draw_dsc;
+    lv_layer_t * layer = draw_dsc_base->layer;
+
+    if(layer == NULL) {
+        return;
+    }
+
+    epic_label_ctx_t ctx = {0};
+    ctx.draw_unit.target_layer = layer;
+    ctx.draw_unit.clip_area = &task->clip_area;
+
+    lv_draw_label_iterate_characters(&ctx.draw_unit, dsc, &task->area, draw_letter_cb);
+    (void)lv_epic_cont_blend_reset();
+
+    for(uint32_t i = 0; i < 2U; i++) {
+        if(ctx.glyph_stage[i] != NULL) {
+            lv_draw_buf_destroy(ctx.glyph_stage[i]);
+        }
+    }
+#endif
+}
+
+/**********************
+ *   STATIC FUNCTIONS
+ **********************/
+
+static void draw_letter_cb(lv_draw_unit_t * draw_unit, lv_draw_glyph_dsc_t * glyph_draw_dsc,
+                           lv_draw_fill_dsc_t * fill_draw_dsc, const lv_area_t * fill_area)
+{
+    if(glyph_draw_dsc) {
+        switch(glyph_draw_dsc->format) {
+            case LV_FONT_GLYPH_FORMAT_NONE: {
+#if LV_USE_FONT_PLACEHOLDER
+                    draw_placeholder_border(draw_unit, glyph_draw_dsc);
+#endif
+                    break;
+                }
+
+            case LV_FONT_GLYPH_FORMAT_A1:
+            case LV_FONT_GLYPH_FORMAT_A2:
+            case LV_FONT_GLYPH_FORMAT_A4:
+            case LV_FONT_GLYPH_FORMAT_A8:
+                if(glyph_draw_dsc->rotation % 3600 == 0) {
+                    draw_bitmap_glyph(draw_unit, glyph_draw_dsc);
+                }
+                else {
+                    draw_glyph_as_image(draw_unit, glyph_draw_dsc);
+                }
+                break;
+
+            case LV_FONT_GLYPH_FORMAT_IMAGE:
+                draw_glyph_as_image(draw_unit, glyph_draw_dsc);
+                break;
+
+            default:
+                break;
+        }
+    }
+
+    if(fill_draw_dsc && fill_area) {
+        draw_fill_part(draw_unit, fill_draw_dsc, fill_area);
+    }
+}
+
+static void draw_placeholder_border(lv_draw_unit_t * draw_unit, lv_draw_glyph_dsc_t * glyph_draw_dsc)
+{
+    if(glyph_draw_dsc->bg_coords == NULL) {
+        return;
+    }
+
+    lv_draw_border_dsc_t border_draw_dsc;
+    lv_draw_border_dsc_init(&border_draw_dsc);
+    border_draw_dsc.opa = glyph_draw_dsc->opa;
+    border_draw_dsc.color = glyph_draw_dsc->color;
+    border_draw_dsc.width = 1;
+    border_draw_dsc.base.layer = draw_unit->target_layer;
+
+    lv_draw_task_t border_task;
+    if(!create_task_from_draw_unit(draw_unit, &border_task, &border_draw_dsc, glyph_draw_dsc->bg_coords)) {
+        return;
+    }
+
+    lv_draw_sifli_epic_border(&border_task);
+}
+
+static void draw_bitmap_glyph(lv_draw_unit_t * draw_unit, lv_draw_glyph_dsc_t * glyph_draw_dsc)
+{
+    if(glyph_draw_dsc->opa <= LV_OPA_MIN || glyph_draw_dsc->g == NULL || glyph_draw_dsc->letter_coords == NULL) {
+        return;
+    }
+
+    if(glyph_draw_dsc->glyph_data == NULL) {
+        return;
+    }
+
+    const lv_draw_buf_t * glyph_buf = (const lv_draw_buf_t *)glyph_draw_dsc->glyph_data;
+    if(glyph_buf->data == NULL) {
+        EPIC_ASSERT_MSG(false, "EPIC: Bitmap glyph buffer has no data");
+        return;
+    }
+
+    epic_label_ctx_t * ctx = (epic_label_ctx_t *)draw_unit;
+    lv_draw_buf_t * staged_buf = stage_glyph_bitmap(ctx, glyph_buf);
+    if(staged_buf == NULL) {
+        (void)lv_epic_cont_blend_reset();
+        staged_buf = (lv_draw_buf_t *)glyph_buf;
+    }
+
+    EPIC_LayerConfigTypeDef bg_layer;
+    EPIC_LayerConfigTypeDef output_layer;
+
+    lv_draw_fill_dsc_t layer_dsc;
+    lv_draw_fill_dsc_init(&layer_dsc);
+    layer_dsc.base.layer = draw_unit->target_layer;
+
+    lv_draw_task_t task;
+    if(!create_task_from_draw_unit(draw_unit, &task, &layer_dsc, glyph_draw_dsc->letter_coords)) {
+        return;
+    }
+
+    if(lv_epic_setup_layers(&bg_layer, &output_layer, &task, glyph_draw_dsc->letter_coords)) {
+        return;
+    }
+
+    EPIC_LayerConfigTypeDef input_layers[2];
+    input_layers[0] = bg_layer;
+    HAL_EPIC_LayerConfigInit(&input_layers[1]);
+
+    input_layers[1].data = staged_buf->data;
+    input_layers[1].color_mode = lv_img_cf_to_epic_cf(staged_buf->header.cf);
+    input_layers[1].width = staged_buf->header.w;
+    input_layers[1].height = staged_buf->header.h;
+    input_layers[1].total_width = lv_epic_stride_to_width(staged_buf->header.stride, staged_buf->header.cf);
+    input_layers[1].x_offset = glyph_draw_dsc->letter_coords->x1;
+    input_layers[1].y_offset = glyph_draw_dsc->letter_coords->y1;
+    input_layers[1].alpha = glyph_draw_dsc->opa;
+    input_layers[1].color_en = true;
+    input_layers[1].color_r = glyph_draw_dsc->color.red;
+    input_layers[1].color_g = glyph_draw_dsc->color.green;
+    input_layers[1].color_b = glyph_draw_dsc->color.blue;
+    input_layers[1].ax_mode = ALPHA_BLEND_RGBCOLOR;
+
+    if(lv_epic_cont_blend(input_layers, 2, &output_layer) != HAL_OK) {
+        (void)lv_epic_blend(input_layers, 2, &output_layer);
+    }
+}
+
+static void draw_glyph_as_image(lv_draw_unit_t * draw_unit, lv_draw_glyph_dsc_t * glyph_draw_dsc)
+{
+    if(glyph_draw_dsc->opa <= LV_OPA_MIN || glyph_draw_dsc->g == NULL || glyph_draw_dsc->letter_coords == NULL) {
+        return;
+    }
+
+    if(glyph_draw_dsc->glyph_data == NULL) {
+        return;
+    }
+
+    lv_draw_image_dsc_t img_dsc;
+    lv_draw_image_dsc_init(&img_dsc);
+    img_dsc.rotation = glyph_draw_dsc->rotation;
+    img_dsc.scale_x = LV_SCALE_NONE;
+    img_dsc.scale_y = LV_SCALE_NONE;
+    img_dsc.opa = glyph_draw_dsc->opa;
+    img_dsc.src = glyph_draw_dsc->glyph_data;
+    img_dsc.recolor = glyph_draw_dsc->color;
+    img_dsc.pivot.x = glyph_draw_dsc->pivot.x;
+    img_dsc.pivot.y = glyph_draw_dsc->g ? (glyph_draw_dsc->g->box_h + glyph_draw_dsc->g->ofs_y) : 0;
+    img_dsc.base.layer = draw_unit->target_layer;
+
+    lv_draw_task_t img_task;
+    if(!create_task_from_draw_unit(draw_unit, &img_task, &img_dsc, glyph_draw_dsc->letter_coords)) {
+        return;
+    }
+
+    lv_draw_sifli_epic_img(&img_task);
+}
+
+static void draw_fill_part(lv_draw_unit_t * draw_unit, lv_draw_fill_dsc_t * fill_draw_dsc, const lv_area_t * fill_area)
+{
+    lv_draw_fill_dsc_t local_dsc = *fill_draw_dsc;
+    local_dsc.base.layer = draw_unit->target_layer;
+
+    lv_draw_task_t fill_task;
+    if(!create_task_from_draw_unit(draw_unit, &fill_task, &local_dsc, fill_area)) {
+        return;
+    }
+
+    lv_draw_sifli_epic_fill(&fill_task);
+}
+
+static bool create_task_from_draw_unit(lv_draw_unit_t * draw_unit, lv_draw_task_t * task, void * draw_dsc,
+                                       const lv_area_t * area)
+{
+    if(draw_unit == NULL || draw_unit->target_layer == NULL || draw_unit->clip_area == NULL ||
+       task == NULL || draw_dsc == NULL || area == NULL) {
+        return false;
+    }
+
+    *task = (lv_draw_task_t) {0};
+    task->draw_dsc = draw_dsc;
+    task->area = *area;
+    task->_real_area = *area;
+    task->clip_area = *draw_unit->clip_area;
+    task->clip_area_original = task->clip_area;
+
+    return true;
+}
+
+static lv_draw_buf_t * stage_glyph_bitmap(epic_label_ctx_t * ctx, const lv_draw_buf_t * glyph_buf)
+{
+    uint8_t stage_index = ctx->next_stage;
+    lv_draw_buf_t * stage = ctx->glyph_stage[stage_index];
+
+    if(stage != NULL &&
+       lv_draw_buf_reshape(stage, glyph_buf->header.cf, glyph_buf->header.w,
+                           glyph_buf->header.h, glyph_buf->header.stride) == NULL) {
+        lv_draw_buf_destroy(stage);
+        stage = NULL;
+    }
+
+    if(stage == NULL) {
+        stage = lv_draw_buf_create(glyph_buf->header.w, glyph_buf->header.h,
+                                   glyph_buf->header.cf, glyph_buf->header.stride);
+        if(stage == NULL) {
+            return NULL;
+        }
+        ctx->glyph_stage[stage_index] = stage;
+    }
+
+    lv_draw_buf_copy(stage, NULL, glyph_buf, NULL);
+    ctx->next_stage ^= 1U;
+    return stage;
+}
+
+#endif /*LV_USE_SIFLI_EPIC*/

--- a/src/draw/sifli/epic/lv_draw_sifli_epic_layer.c
+++ b/src/draw/sifli/epic/lv_draw_sifli_epic_layer.c
@@ -1,0 +1,81 @@
+/**
+ * @file lv_draw_sifli_epic_layer.c
+ *
+ */
+
+/**
+ * Copyright 2024 SiFli Technologies
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+/*********************
+ *      INCLUDES
+ *********************/
+
+#include "lv_draw_sifli_epic.h"
+
+#if LV_USE_SIFLI_EPIC
+#include "lv_sifli_epic_utils.h"
+/*********************
+ *      DEFINES
+ *********************/
+
+/**********************
+ *      TYPEDEFS
+ **********************/
+
+/**********************
+ *  STATIC PROTOTYPES
+ **********************/
+
+/**********************
+ *  STATIC VARIABLES
+ **********************/
+
+/**********************
+ *      MACROS
+ **********************/
+
+/**********************
+ *   GLOBAL FUNCTIONS
+ **********************/
+
+void lv_draw_sifli_epic_layer(lv_draw_task_t * task)
+{
+    const lv_draw_image_dsc_t * dsc = (const lv_draw_image_dsc_t *)task->draw_dsc;
+    lv_layer_t * layer_to_draw = (lv_layer_t *)dsc->src;
+
+    if(dsc->opa <= LV_OPA_MIN) {
+        return;
+    }
+
+    if(layer_to_draw == NULL) {
+        EPIC_ASSERT_MSG(false, "EPIC: Layer source is null");
+        return;
+    }
+
+    if(layer_to_draw->draw_buf == NULL) {
+        EPIC_ASSERT_MSG(false, "EPIC: Layer source draw buffer is null");
+        return;
+    }
+
+    /* Keep layer composition on the same image path as normal draw_buf sources.
+     * This matches the mature downstream route and avoids duplicating source
+     * layout/format handling for temporary layers. */
+    lv_draw_buf_flush_cache(layer_to_draw->draw_buf, NULL);
+
+    lv_draw_image_dsc_t new_draw_dsc = *dsc;
+    new_draw_dsc.src = layer_to_draw->draw_buf;
+
+    lv_draw_task_t img_task = *task;
+    img_task.draw_dsc = &new_draw_dsc;
+
+    lv_draw_sifli_epic_img(&img_task);
+}
+
+/**********************
+ *   STATIC FUNCTIONS
+ **********************/
+
+#endif /*LV_USE_SIFLI_EPIC*/

--- a/src/draw/sifli/epic/lv_sifli_epic_cfg.c
+++ b/src/draw/sifli/epic/lv_sifli_epic_cfg.c
@@ -1,0 +1,527 @@
+/**
+ * @file lv_sifli_epic_cfg.c
+ *
+ */
+
+/**
+ * Copyright 2024 SiFli Technologies
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+/*********************
+ *      INCLUDES
+ *********************/
+
+#include "lv_sifli_epic_cfg.h"
+#include "lv_sifli_epic_osa.h"
+
+#if LV_USE_SIFLI_EPIC
+#include "../../../misc/lv_log.h"
+#include <inttypes.h>
+#include "system_bf0_ap.h"
+#include <string.h>
+#include <syslog.h>
+
+#if defined(__ZEPHYR__)
+    #include <zephyr/arch/cache.h>
+#endif
+
+#if defined(__NuttX__)
+    #include <arch/irq.h>
+    #include <nuttx/arch.h>
+    #include <nuttx/cache.h>
+    #include <nuttx/clock.h>
+
+    #ifndef NVIC_IRQ_FIRST
+        #define NVIC_IRQ_FIRST 16
+    #endif
+#endif
+
+/**********************
+ *      DEFINES
+ *********************/
+
+/**********************
+ *      TYPEDEFS
+ **********************/
+
+/**********************
+ *  STATIC PROTOTYPES
+ **********************/
+
+/**********************
+ *  STATIC VARIABLES
+ **********************/
+
+static EPIC_HandleTypeDef epic_handle;
+#ifdef HAL_EZIP_MODULE_ENABLED
+    static EZIP_HandleTypeDef ezip_handle;
+#endif
+static bool epic_initialized = false;
+static bool epic_cont_active = false;
+static lv_epic_cplt_cbk epic_async_cb;
+
+/**********************
+ *  STATIC PROTOTYPES
+ **********************/
+
+static void epic_xfer_cplt_callback(EPIC_HandleTypeDef * epic);
+static HAL_StatusTypeDef epic_wait_async_result(HAL_StatusTypeDef start_status);
+static HAL_StatusTypeDef epic_prepare_start(EPIC_HandleTypeDef * epic,
+                                            lv_epic_cplt_cbk cb);
+static void epic_start_failed_cleanup(void);
+static HAL_StatusTypeDef epic_cont_wait_done(const char * operation);
+static HAL_StatusTypeDef epic_recover(void);
+static uint32_t epic_tick_get(void);
+
+/**********************
+ *      MACROS
+ **********************/
+
+/**********************
+ *   GLOBAL FUNCTIONS
+ **********************/
+
+void lv_epic_init(void)
+{
+    if(epic_initialized) {
+        return;
+    }
+
+    memset(&epic_handle, 0, sizeof(epic_handle));
+    epic_handle.Instance = LV_SIFLI_EPIC_INSTANCE;
+
+#ifdef HAL_EZIP_MODULE_ENABLED
+    memset(&ezip_handle, 0, sizeof(ezip_handle));
+    ezip_handle.Instance = EZIP;
+    epic_handle.hezip = &ezip_handle;
+
+    if(HAL_EZIP_Init(epic_handle.hezip) != HAL_OK) {
+        return;
+    }
+#endif
+
+    if(HAL_EPIC_Init(&epic_handle) != HAL_OK) {
+        return;
+    }
+
+    if(lv_epic_osa_init() != LV_RESULT_OK) {
+        memset(&epic_handle, 0, sizeof(epic_handle));
+#ifdef HAL_EZIP_MODULE_ENABLED
+        memset(&ezip_handle, 0, sizeof(ezip_handle));
+#endif
+        return;
+    }
+
+    epic_initialized = true;
+    epic_cont_active = false;
+}
+
+void lv_epic_deinit(void)
+{
+    if(!epic_initialized) {
+        return;
+    }
+
+    lv_epic_wait();
+    lv_epic_osa_deinit();
+
+    memset(&epic_handle, 0, sizeof(epic_handle));
+#ifdef HAL_EZIP_MODULE_ENABLED
+        memset(&ezip_handle, 0, sizeof(ezip_handle));
+#endif
+    epic_async_cb = NULL;
+    epic_cont_active = false;
+    epic_initialized = false;
+}
+
+bool lv_epic_is_initialized(void)
+{
+    return epic_initialized;
+}
+
+bool lv_epic_is_busy(void)
+{
+    if(!epic_initialized) {
+        return false;
+    }
+
+    if(epic_handle.State == HAL_EPIC_STATE_BUSY) {
+        return true;
+    }
+
+#ifdef HAL_EZIP_MODULE_ENABLED
+    if(ezip_handle.State == HAL_EZIP_STATE_BUSY) {
+        return true;
+    }
+#endif
+
+    return false;
+}
+
+void lv_epic_run(void)
+{
+    epic_osa_cfg_t * cfg = epic_get_default_cfg();
+    if(cfg && cfg->epic_run) {
+        cfg->epic_run();
+    }
+}
+
+HAL_StatusTypeDef lv_epic_wait(void)
+{
+    if(epic_cont_active) {
+        return lv_epic_cont_blend_reset();
+    }
+
+    epic_osa_cfg_t * cfg = epic_get_default_cfg();
+    if(cfg && cfg->epic_wait) {
+        cfg->epic_wait();
+    }
+
+    if(lv_epic_osa_take_wait_failure()) {
+        if(epic_handle.Instance != NULL) {
+            syslog(LOG_ERR,
+                   "[lv_epic][wait_timeout] status=%08" PRIx32
+                   " command=%08" PRIx32 " setting=%08" PRIx32
+                   " state=%d error=%08" PRIx32 "\n",
+                   epic_handle.Instance->STATUS,
+                   epic_handle.Instance->COMMAND,
+                   epic_handle.Instance->SETTING,
+                   (int)epic_handle.State, epic_handle.ErrorCode);
+        }
+        return epic_recover() == HAL_OK ? HAL_TIMEOUT : HAL_ERROR;
+    }
+
+    return HAL_OK;
+}
+
+EPIC_HandleTypeDef * lv_epic_get_handle(void)
+{
+    if(!epic_initialized) {
+        return NULL;
+    }
+
+    return &epic_handle;
+}
+
+#ifdef HAL_EZIP_MODULE_ENABLED
+EZIP_HandleTypeDef * lv_ezip_get_handle(void)
+{
+    if(!epic_initialized) {
+        return NULL;
+    }
+
+    return &ezip_handle;
+}
+#endif
+
+void lv_epic_flush_cache_range(const void * data, uint32_t size)
+{
+    if(data == NULL || size == 0U) {
+        return;
+    }
+
+#if defined(__ZEPHYR__)
+    (void)arch_dcache_flush_range((void *)data, size);
+#elif defined(__NuttX__)
+    /* SF32LB52 configures PSRAM as write-through.  The SDK helper makes
+     * clean a no-op in that mode and keeps the write-back case correct. */
+    (void)mpu_dcache_clean((void *)data, size);
+#else
+    mpu_dcache_clean((void *)data, size);
+#endif
+}
+
+void lv_epic_invalidate_cache_range(const void * data, uint32_t size)
+{
+    if(data == NULL || size == 0U) {
+        return;
+    }
+
+#if defined(__ZEPHYR__)
+    (void)arch_dcache_invd_range((void *)data, size);
+#elif defined(__NuttX__)
+    /* Use the SiFli cache-size-aware path.  It invalidates the whole 16 KiB
+     * D-cache for larger regions instead of walking every address line. */
+    (void)mpu_dcache_invalidate((void *)data, size);
+#else
+    mpu_dcache_invalidate((void *)data, size);
+#endif
+}
+
+bool lv_epic_is_cached_ram(uint32_t start, uint32_t len)
+{
+    LV_UNUSED(len);
+
+#if defined(__NuttX__)
+    return IS_DCACHED_RAM(start);
+#elif defined(__DCACHE_PRESENT) && (__DCACHE_PRESENT == 1U)
+    LV_UNUSED(start);
+    return true;
+#else
+    LV_UNUSED(start);
+    return false;
+#endif
+}
+
+HAL_StatusTypeDef lv_epic_fill(EPIC_LayerConfigTypeDef * input_layers, uint8_t input_layer_cnt,
+                               EPIC_LayerConfigTypeDef * output_layer)
+{
+    EPIC_HandleTypeDef * epic = lv_epic_get_handle();
+
+    if(epic_prepare_start(epic, NULL) != HAL_OK) {
+        return HAL_ERROR;
+    }
+    HAL_StatusTypeDef start_status = HAL_EPIC_BlendStartEx_IT(epic, input_layers, input_layer_cnt, output_layer);
+    return epic_wait_async_result(start_status);
+}
+
+HAL_StatusTypeDef lv_epic_blend(EPIC_LayerConfigTypeDef * input_layers, uint8_t input_layer_cnt,
+                                EPIC_LayerConfigTypeDef * output_layer)
+{
+    EPIC_HandleTypeDef * epic = lv_epic_get_handle();
+
+    if(epic_prepare_start(epic, NULL) != HAL_OK) {
+        return HAL_ERROR;
+    }
+    HAL_StatusTypeDef start_status = HAL_EPIC_BlendStartEx_IT(epic, input_layers, input_layer_cnt, output_layer);
+    return epic_wait_async_result(start_status);
+}
+
+HAL_StatusTypeDef lv_epic_cont_blend(EPIC_LayerConfigTypeDef * input_layers, uint8_t input_layer_cnt,
+                                     EPIC_LayerConfigTypeDef * output_layer)
+{
+    EPIC_HandleTypeDef * epic = lv_epic_get_handle();
+    HAL_StatusTypeDef status;
+
+    if(epic == NULL || input_layers == NULL || output_layer == NULL ||
+       (input_layer_cnt != 2U && input_layer_cnt != 3U)) {
+        return HAL_ERROR;
+    }
+
+    EPIC_LayerConfigTypeDef * fg_layer = &input_layers[1];
+    EPIC_LayerConfigTypeDef * mask_layer = input_layer_cnt == 3U ? &input_layers[2] : NULL;
+
+    if(!epic_cont_active) {
+        if(epic->State == HAL_EPIC_STATE_BUSY) {
+            if(lv_epic_wait() != HAL_OK) {
+                return HAL_ERROR;
+            }
+        }
+
+        epic_async_cb = NULL;
+        epic->XferCpltCallback = NULL;
+        epic->IntXferCpltCallback = NULL;
+        status = HAL_EPIC_ContBlendStart(epic, fg_layer, mask_layer, output_layer);
+        if(status == HAL_OK) {
+            epic_cont_active = true;
+        }
+    }
+    else {
+        status = epic_cont_wait_done("repeat");
+        if(status == HAL_OK) {
+            status = HAL_EPIC_ContBlendRepeat(epic, fg_layer, mask_layer, output_layer);
+        }
+    }
+
+    if(status != HAL_OK) {
+        if(epic_cont_active) {
+            (void)HAL_EPIC_ContBlendStop(epic);
+        }
+        epic_cont_active = false;
+        lv_epic_osa_set_idle();
+    }
+
+    return status;
+}
+
+HAL_StatusTypeDef lv_epic_cont_blend_reset(void)
+{
+    if(!epic_cont_active) {
+        return HAL_OK;
+    }
+
+    HAL_StatusTypeDef status = epic_cont_wait_done("stop");
+    if(status == HAL_OK) {
+        status = HAL_EPIC_ContBlendStop(&epic_handle);
+    }
+    epic_cont_active = false;
+    lv_epic_osa_set_idle();
+    return status;
+}
+
+HAL_StatusTypeDef lv_epic_fill_grad(EPIC_GradCfgTypeDef * param)
+{
+    EPIC_HandleTypeDef * epic = lv_epic_get_handle();
+
+    if(epic_prepare_start(epic, NULL) != HAL_OK) {
+        return HAL_ERROR;
+    }
+    HAL_StatusTypeDef start_status = HAL_EPIC_FillGrad_IT(epic, param);
+    return epic_wait_async_result(start_status);
+}
+
+HAL_StatusTypeDef lv_epic_copy(EPIC_BlendingDataType * src, EPIC_BlendingDataType * dst)
+{
+    EPIC_HandleTypeDef * epic = lv_epic_get_handle();
+
+    if(epic_prepare_start(epic, NULL) != HAL_OK) {
+        return HAL_ERROR;
+    }
+    HAL_StatusTypeDef start_status = HAL_EPIC_Copy_IT(epic, src, dst);
+    return epic_wait_async_result(start_status);
+}
+
+HAL_StatusTypeDef lv_epic_copy_async(EPIC_BlendingDataType * src, EPIC_BlendingDataType * dst,
+                                     lv_epic_cplt_cbk cb)
+{
+    EPIC_HandleTypeDef * epic = lv_epic_get_handle();
+
+    if(epic_prepare_start(epic, cb) != HAL_OK) {
+        return HAL_ERROR;
+    }
+
+    HAL_StatusTypeDef start_status = HAL_EPIC_Copy_IT(epic, src, dst);
+    if(start_status != HAL_OK) {
+        LV_LOG_WARN("EPIC async copy start failed: status=%d", (int)start_status);
+        epic_start_failed_cleanup();
+    }
+
+    return start_status;
+}
+
+/**********************
+ *   STATIC FUNCTIONS
+ **********************/
+
+static void epic_xfer_cplt_callback(EPIC_HandleTypeDef * epic)
+{
+    lv_epic_osa_thread_sync_signal_isr();
+
+    if(epic_async_cb != NULL) {
+        lv_epic_cplt_cbk cb = epic_async_cb;
+        epic_async_cb = NULL;
+        cb(epic);
+    }
+}
+
+static HAL_StatusTypeDef epic_wait_async_result(HAL_StatusTypeDef start_status)
+{
+    if(start_status != HAL_OK) {
+        LV_LOG_WARN("EPIC start failed: status=%d", (int)start_status);
+        epic_start_failed_cleanup();
+        return start_status;
+    }
+
+    return lv_epic_wait();
+}
+
+static HAL_StatusTypeDef epic_prepare_start(EPIC_HandleTypeDef * epic,
+                                            lv_epic_cplt_cbk cb)
+{
+    if(epic == NULL) {
+        return HAL_ERROR;
+    }
+
+    if(lv_epic_is_busy()) {
+        if(lv_epic_wait() != HAL_OK) {
+            return HAL_ERROR;
+        }
+    }
+
+    epic_async_cb = cb;
+    epic->XferCpltCallback = epic_xfer_cplt_callback;
+    lv_epic_run();
+    return HAL_OK;
+}
+
+static void epic_start_failed_cleanup(void)
+{
+    epic_handle.XferCpltCallback = NULL;
+    epic_async_cb = NULL;
+    lv_epic_osa_set_idle();
+}
+
+static HAL_StatusTypeDef epic_cont_wait_done(const char * operation)
+{
+    uint32_t spin_count = 0;
+    uint32_t start_tick;
+
+    if(!HAL_EPIC_IsHWBusy(&epic_handle)) {
+        return HAL_OK;
+    }
+
+    start_tick = epic_tick_get();
+
+    while(HAL_EPIC_IsHWBusy(&epic_handle)) {
+        if((++spin_count & 0xffU) == 0U &&
+           epic_tick_get() - start_tick >= LV_SIFLI_EPIC_CONT_TIMEOUT_MS) {
+            syslog(LOG_ERR,
+                   "[lv_epic][cont_timeout] op=%s elapsed=%" PRIu32
+                   "ms status=%08" PRIx32 " command=%08" PRIx32
+                   " setting=%08" PRIx32 " state=%d error=%08" PRIx32 "\n",
+                   operation, epic_tick_get() - start_tick,
+                   epic_handle.Instance->STATUS,
+                   epic_handle.Instance->COMMAND,
+                   epic_handle.Instance->SETTING,
+                   (int)epic_handle.State, epic_handle.ErrorCode);
+            (void)epic_recover();
+            return HAL_TIMEOUT;
+        }
+    }
+
+    return HAL_OK;
+}
+
+static uint32_t epic_tick_get(void)
+{
+#if defined(__NuttX__)
+    return (uint32_t)TICK2MSEC(clock_systime_ticks());
+#else
+    return HAL_GetTick();
+#endif
+}
+
+static HAL_StatusTypeDef epic_recover(void)
+{
+    HAL_StatusTypeDef status;
+
+#if defined(__NuttX__)
+    int nuttx_irq = (int)LV_SIFLI_EPIC_IRQn + NVIC_IRQ_FIRST;
+    up_disable_irq(nuttx_irq);
+#else
+    HAL_NVIC_DisableIRQ(LV_SIFLI_EPIC_IRQn);
+#endif
+    HAL_NVIC_ClearPendingIRQ(LV_SIFLI_EPIC_IRQn);
+    HAL_RCC_ResetModule(RCC_MOD_EPIC);
+
+    memset(&epic_handle, 0, sizeof(epic_handle));
+    epic_handle.Instance = LV_SIFLI_EPIC_INSTANCE;
+#ifdef HAL_EZIP_MODULE_ENABLED
+    epic_handle.hezip = &ezip_handle;
+#endif
+    status = HAL_EPIC_Init(&epic_handle);
+
+    epic_async_cb = NULL;
+    epic_cont_active = false;
+    lv_epic_osa_set_idle();
+
+    if(status == HAL_OK) {
+        HAL_NVIC_ClearPendingIRQ(LV_SIFLI_EPIC_IRQn);
+#if defined(__NuttX__)
+        up_enable_irq(nuttx_irq);
+#else
+        HAL_NVIC_EnableIRQ(LV_SIFLI_EPIC_IRQn);
+#endif
+        syslog(LOG_WARNING, "[lv_epic][recover] EPIC reinitialized\n");
+    }
+    else {
+        epic_initialized = false;
+        syslog(LOG_ERR, "[lv_epic][recover] EPIC reinit failed: %d\n", (int)status);
+    }
+
+    return status;
+}
+
+#endif /*LV_USE_SIFLI_EPIC*/

--- a/src/draw/sifli/epic/lv_sifli_epic_cfg.h
+++ b/src/draw/sifli/epic/lv_sifli_epic_cfg.h
@@ -1,0 +1,196 @@
+/**
+ * @file lv_sifli_epic_cfg.h
+ *
+ */
+
+/**
+ * Copyright 2024 SiFli Technologies
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#ifndef LV_SIFLI_EPIC_CFG_H
+#define LV_SIFLI_EPIC_CFG_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*********************
+ *      INCLUDES
+ *********************/
+
+#include "../../../lv_conf_internal.h"
+
+#if LV_USE_SIFLI_EPIC
+
+/* Include SiFli HAL headers - these should be provided by the platform */
+#include "bf0_hal.h"
+#include "../../../draw/lv_image_dsc.h"
+#include "../../../misc/lv_color.h"
+
+#include "../../../misc/lv_log.h"
+
+/*********************
+ *      DEFINES
+ *********************/
+
+/** EPIC module instance to use (platform-specific) */
+#ifndef LV_SIFLI_EPIC_INSTANCE
+#define LV_SIFLI_EPIC_INSTANCE EPIC
+#endif
+
+/** EPIC interrupt line ID (platform-specific) */
+#ifndef LV_SIFLI_EPIC_IRQn
+#define LV_SIFLI_EPIC_IRQn EPIC_IRQn
+#endif
+
+/** EPIC interrupt priority (platform-specific) */
+#ifndef LV_SIFLI_EPIC_IRQ_PRIORITY
+#define LV_SIFLI_EPIC_IRQ_PRIORITY 5
+#endif
+
+#ifdef HAL_EZIP_MODULE_ENABLED
+/** EZIP interrupt line ID (platform-specific) */
+#ifndef LV_SIFLI_EZIP_IRQn
+#define LV_SIFLI_EZIP_IRQn EZIP_IRQn
+#endif
+#endif
+
+#if LV_USE_OS == LV_OS_FREERTOS
+#if defined(configLIBRARY_MAX_SYSCALL_INTERRUPT_PRIORITY)
+#ifndef LV_SIFLI_EPIC_FREERTOS_IRQ_PRIORITY
+#define LV_SIFLI_EPIC_FREERTOS_IRQ_PRIORITY (configLIBRARY_MAX_SYSCALL_INTERRUPT_PRIORITY + 1)
+#endif
+#endif
+#endif
+
+#ifdef __ZEPHYR__
+#ifndef LV_SIFLI_EPIC_ZEPHYR_IRQ_FLAGS
+#define LV_SIFLI_EPIC_ZEPHYR_IRQ_FLAGS 0
+#endif
+#endif
+
+#ifdef __NuttX__
+#ifndef LV_SIFLI_EPIC_NUTTX_IRQ_PRIORITY
+#define LV_SIFLI_EPIC_NUTTX_IRQ_PRIORITY NVIC_SYSH_PRIORITY_DEFAULT
+#endif
+#endif
+
+#ifndef LV_SIFLI_EPIC_CONT_TIMEOUT_MS
+#define LV_SIFLI_EPIC_CONT_TIMEOUT_MS 100U
+#endif
+
+/** Maximum pixels for single EPIC operation */
+#define EPIC_MAX_PIXELS (1000 * 1000)
+
+/*
+ * Keep SiFli image extension flags local to the adapter if the host LVGL
+ * integration hasn't provided them already.
+ */
+#ifndef LV_IMAGE_FLAGS_EZIP
+#define LV_IMAGE_FLAGS_EZIP LV_IMAGE_FLAGS_USER1
+#endif
+
+#ifndef LV_IMAGE_FLAGS_JPEG
+#define LV_IMAGE_FLAGS_JPEG LV_IMAGE_FLAGS_USER2
+#endif
+
+/**********************
+ *      TYPEDEFS
+ **********************/
+
+typedef void (*lv_epic_cplt_cbk)(EPIC_HandleTypeDef * epic);
+
+/**********************
+ * GLOBAL PROTOTYPES
+ **********************/
+
+/**
+ * Reset and initialize EPIC device. This function should be called as part
+ * of display init sequence.
+ */
+void lv_epic_init(void);
+
+/**
+ * Disable EPIC device. Should be called during display deinit sequence.
+ */
+void lv_epic_deinit(void);
+
+/**
+ * Check whether the external EPIC adapter has completed initialization.
+ * @return true if initialized, false otherwise
+ */
+bool lv_epic_is_initialized(void);
+
+/**
+ * Check whether the external EPIC adapter currently owns an in-flight job.
+ * @return true if EPIC/EZIP is busy, false otherwise
+ */
+bool lv_epic_is_busy(void);
+
+/**
+ * Clear cache and start EPIC.
+ */
+void lv_epic_run(void);
+
+/**
+ * Wait for EPIC completion.
+ */
+HAL_StatusTypeDef lv_epic_wait(void);
+
+/**
+ * Get EPIC HAL handle.
+ * @return Pointer to EPIC handle
+ */
+EPIC_HandleTypeDef * lv_epic_get_handle(void);
+
+#ifdef HAL_EZIP_MODULE_ENABLED
+EZIP_HandleTypeDef * lv_ezip_get_handle(void);
+#endif
+
+/**
+ * Flush a cache range before EPIC reads CPU-generated data.
+ * @param data Start address
+ * @param size Range size in bytes
+ */
+void lv_epic_flush_cache_range(const void * data, uint32_t size);
+
+/**
+ * Clean and invalidate a cache range before EPIC reads/writes a shared buffer.
+ * @param data Start address
+ * @param size Range size in bytes
+ */
+void lv_epic_invalidate_cache_range(const void * data, uint32_t size);
+
+/**
+ * Check if memory region is cached.
+ * @param start Start address
+ * @param len Memory length
+ * @return true if cached, false otherwise
+ */
+bool lv_epic_is_cached_ram(uint32_t start, uint32_t len);
+
+HAL_StatusTypeDef lv_epic_fill(EPIC_LayerConfigTypeDef * input_layers, uint8_t input_layer_cnt,
+                               EPIC_LayerConfigTypeDef * output_layer);
+HAL_StatusTypeDef lv_epic_blend(EPIC_LayerConfigTypeDef * input_layers, uint8_t input_layer_cnt,
+                                EPIC_LayerConfigTypeDef * output_layer);
+HAL_StatusTypeDef lv_epic_cont_blend(EPIC_LayerConfigTypeDef * input_layers, uint8_t input_layer_cnt,
+                                     EPIC_LayerConfigTypeDef * output_layer);
+HAL_StatusTypeDef lv_epic_cont_blend_reset(void);
+HAL_StatusTypeDef lv_epic_fill_grad(EPIC_GradCfgTypeDef * param);
+HAL_StatusTypeDef lv_epic_copy(EPIC_BlendingDataType * src, EPIC_BlendingDataType * dst);
+HAL_StatusTypeDef lv_epic_copy_async(EPIC_BlendingDataType * src, EPIC_BlendingDataType * dst,
+                                     lv_epic_cplt_cbk cb);
+
+/**********************
+ *      MACROS
+ **********************/
+
+#endif /*LV_USE_SIFLI_EPIC*/
+
+#ifdef __cplusplus
+} /*extern "C"*/
+#endif
+
+#endif /*LV_SIFLI_EPIC_CFG_H*/

--- a/src/draw/sifli/epic/lv_sifli_epic_osa.c
+++ b/src/draw/sifli/epic/lv_sifli_epic_osa.c
@@ -1,0 +1,415 @@
+/**
+ * @file lv_sifli_epic_osa.c
+ *
+ */
+
+/**
+ * Copyright 2024 SiFli Technologies
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+/*********************
+ *      INCLUDES
+ *********************/
+
+#include "lv_sifli_epic_osa.h"
+#include "lv_sifli_epic_cfg.h"
+
+#if LV_USE_SIFLI_EPIC
+#include "../../../osal/lv_os.h"
+
+#if defined(__ZEPHYR__)
+    #include <zephyr/kernel.h>
+    #include <zephyr/irq.h>
+#endif
+
+#if defined(__NuttX__)
+    #include <nuttx/arch.h>
+    #include <nuttx/clock.h>
+    #include <nuttx/irq.h>
+    #include <nuttx/semaphore.h>
+    #include <arch/irq.h>
+    #include <semaphore.h>
+#endif
+
+#if LV_USE_OS == LV_OS_RTTHREAD
+    #include "rtthread.h"
+#endif
+
+/*********************
+ *      DEFINES
+ *********************/
+
+#if defined(__NuttX__)
+    #ifndef NVIC_IRQ_FIRST
+        #define NVIC_IRQ_FIRST 16
+    #endif
+    #define LV_SIFLI_EPIC_NUTTX_IRQ(irqn) ((int)(irqn) + NVIC_IRQ_FIRST)
+    #define LV_SIFLI_EPIC_WAIT_TIMEOUT_US 1000000
+    #define LV_SIFLI_EPIC_WAIT_TIMEOUT_MS 1000U
+#endif
+
+/**********************
+ *  STATIC PROTOTYPES
+ **********************/
+
+static void _epic_interrupt_init(void);
+static void _epic_interrupt_deinit(void);
+static void _epic_run(void);
+static void _epic_wait(void);
+static void _epic_irq_enter(void);
+static void _epic_irq_leave(void);
+
+#if defined(__ZEPHYR__)
+    static void _epic_zephyr_irq_handler(const void * arg);
+    #ifdef HAL_EZIP_MODULE_ENABLED
+        static void _ezip_zephyr_irq_handler(const void * arg);
+    #endif
+#endif
+
+#if defined(__NuttX__)
+    static int _epic_nuttx_irq_handler(int irq, void * context, void * arg);
+    #ifdef HAL_EZIP_MODULE_ENABLED
+        static int _ezip_nuttx_irq_handler(int irq, void * context, void * arg);
+    #endif
+#endif
+
+/**********************
+ *  STATIC VARIABLES
+ **********************/
+
+#if LV_USE_OS && !defined(__NuttX__)
+    static lv_thread_sync_t epic_sync;
+#endif
+#if defined(__NuttX__)
+    static sem_t epic_sem;
+    static bool epic_sem_inited;
+#endif
+static volatile bool epic_idle = true;
+#if defined(__NuttX__)
+static volatile bool epic_wait_failure;
+#endif
+
+static epic_osa_cfg_t _epic_default_cfg = {
+    .epic_interrupt_init = _epic_interrupt_init,
+    .epic_interrupt_deinit = _epic_interrupt_deinit,
+    .epic_run = _epic_run,
+    .epic_wait = _epic_wait,
+};
+
+/**********************
+ *   GLOBAL FUNCTIONS
+ **********************/
+
+#if defined(__ZEPHYR__)
+static void _epic_zephyr_irq_handler(const void * arg)
+{
+    LV_UNUSED(arg);
+    EPIC_IRQHandler();
+}
+
+#ifdef HAL_EZIP_MODULE_ENABLED
+static void _ezip_zephyr_irq_handler(const void * arg)
+{
+    LV_UNUSED(arg);
+    EZIP_IRQHandler();
+}
+#endif
+#endif
+
+#if defined(__NuttX__)
+static int _epic_nuttx_irq_handler(int irq, void * context, void * arg)
+{
+    LV_UNUSED(irq);
+    LV_UNUSED(context);
+    LV_UNUSED(arg);
+    EPIC_IRQHandler();
+    return 0;
+}
+
+#ifdef HAL_EZIP_MODULE_ENABLED
+static int _ezip_nuttx_irq_handler(int irq, void * context, void * arg)
+{
+    LV_UNUSED(irq);
+    LV_UNUSED(context);
+    LV_UNUSED(arg);
+    EZIP_IRQHandler();
+    return 0;
+}
+#endif
+#endif
+
+void EPIC_IRQHandler(void)
+{
+    _epic_irq_enter();
+
+    if(lv_epic_is_initialized()) {
+        EPIC_HandleTypeDef * epic_handle = lv_epic_get_handle();
+        if(epic_handle != NULL) {
+            HAL_EPIC_IRQHandler(epic_handle);
+        }
+    }
+
+    _epic_irq_leave();
+}
+
+#ifdef HAL_EZIP_MODULE_ENABLED
+void EZIP_IRQHandler(void)
+{
+    _epic_irq_enter();
+
+    if(lv_epic_is_initialized()) {
+        EZIP_HandleTypeDef * ezip_handle = lv_ezip_get_handle();
+        if(ezip_handle != NULL) {
+            HAL_EZIP_IRQHandler(ezip_handle);
+        }
+    }
+
+    _epic_irq_leave();
+}
+#endif
+
+epic_osa_cfg_t * epic_get_default_cfg(void)
+{
+    return &_epic_default_cfg;
+}
+
+lv_result_t lv_epic_osa_init(void)
+{
+#if defined(__NuttX__)
+    epic_wait_failure = false;
+#endif
+#if LV_USE_OS
+    if(lv_epic_osa_thread_sync_init() != LV_RESULT_OK) {
+        return LV_RESULT_INVALID;
+    }
+#endif
+    _epic_interrupt_init();
+    return LV_RESULT_OK;
+}
+
+void lv_epic_osa_deinit(void)
+{
+    _epic_interrupt_deinit();
+#if LV_USE_OS
+    lv_epic_osa_thread_sync_delete();
+#endif
+}
+
+lv_result_t lv_epic_osa_thread_sync_init(void)
+{
+#if defined(__NuttX__)
+    if(sem_init(&epic_sem, 0, 0) < 0) {
+        return LV_RESULT_INVALID;
+    }
+    epic_sem_inited = true;
+#elif LV_USE_OS
+    if(lv_thread_sync_init(&epic_sync) != LV_RESULT_OK) {
+        return LV_RESULT_INVALID;
+    }
+#endif
+    return LV_RESULT_OK;
+}
+
+lv_result_t lv_epic_osa_thread_sync_wait(void)
+{
+#if defined(__NuttX__)
+    int ret;
+
+    if(!epic_sem_inited) {
+        return LV_RESULT_INVALID;
+    }
+
+    ret = nxsem_tickwait_uninterruptible(&epic_sem,
+                                         MSEC2TICK(LV_SIFLI_EPIC_WAIT_TIMEOUT_MS));
+
+    if(ret < 0) {
+        epic_wait_failure = true;
+        return LV_RESULT_INVALID;
+    }
+#elif LV_USE_OS
+    if(lv_thread_sync_wait(&epic_sync) != LV_RESULT_OK) {
+        return LV_RESULT_INVALID;
+    }
+#endif
+    return LV_RESULT_OK;
+}
+
+void lv_epic_osa_thread_sync_signal_isr(void)
+{
+    epic_idle = true;
+#if defined(__NuttX__)
+    if(epic_sem_inited) {
+        (void)sem_post(&epic_sem);
+    }
+#elif LV_USE_OS
+    (void)lv_thread_sync_signal(&epic_sync);
+#endif
+}
+
+void lv_epic_osa_set_idle(void)
+{
+    epic_idle = true;
+}
+
+bool lv_epic_osa_take_wait_failure(void)
+{
+#if defined(__NuttX__)
+    bool failed = epic_wait_failure;
+    epic_wait_failure = false;
+    return failed;
+#else
+    return false;
+#endif
+}
+
+void lv_epic_osa_thread_sync_delete(void)
+{
+#if defined(__NuttX__)
+    if(epic_sem_inited) {
+        (void)sem_destroy(&epic_sem);
+        epic_sem_inited = false;
+    }
+#elif LV_USE_OS
+    (void)lv_thread_sync_delete(&epic_sync);
+#endif
+}
+
+/**********************
+ *   STATIC FUNCTIONS
+ **********************/
+
+static void _epic_irq_enter(void)
+{
+#if LV_USE_OS == LV_OS_RTTHREAD
+    rt_interrupt_enter();
+#endif
+}
+
+static void _epic_irq_leave(void)
+{
+#if LV_USE_OS == LV_OS_RTTHREAD
+    rt_interrupt_leave();
+#endif
+}
+
+static void _epic_interrupt_init(void)
+{
+#if defined(__ZEPHYR__)
+    IRQ_CONNECT(LV_SIFLI_EPIC_IRQn, LV_SIFLI_EPIC_IRQ_PRIORITY, _epic_zephyr_irq_handler, NULL,
+                LV_SIFLI_EPIC_ZEPHYR_IRQ_FLAGS);
+    irq_enable(LV_SIFLI_EPIC_IRQn);
+#elif defined(__NuttX__)
+    int nuttx_irq = LV_SIFLI_EPIC_NUTTX_IRQ(LV_SIFLI_EPIC_IRQn);
+    int ret = irq_attach(nuttx_irq, _epic_nuttx_irq_handler, NULL);
+    if(ret == 0) {
+        up_enable_irq(nuttx_irq);
+    }
+#elif LV_USE_OS == LV_OS_FREERTOS && defined(LV_SIFLI_EPIC_FREERTOS_IRQ_PRIORITY)
+    HAL_NVIC_SetPriority(LV_SIFLI_EPIC_IRQn, LV_SIFLI_EPIC_FREERTOS_IRQ_PRIORITY, 0);
+    HAL_NVIC_EnableIRQ(LV_SIFLI_EPIC_IRQn);
+#else
+    HAL_NVIC_SetPriority(LV_SIFLI_EPIC_IRQn, LV_SIFLI_EPIC_IRQ_PRIORITY, 0);
+    HAL_NVIC_EnableIRQ(LV_SIFLI_EPIC_IRQn);
+#endif
+
+#ifdef HAL_EZIP_MODULE_ENABLED
+#if defined(__ZEPHYR__)
+    IRQ_CONNECT(LV_SIFLI_EZIP_IRQn, LV_SIFLI_EPIC_IRQ_PRIORITY, _ezip_zephyr_irq_handler, NULL,
+                LV_SIFLI_EPIC_ZEPHYR_IRQ_FLAGS);
+    irq_enable(LV_SIFLI_EZIP_IRQn);
+#elif defined(__NuttX__)
+    int ezip_nuttx_irq = LV_SIFLI_EPIC_NUTTX_IRQ(LV_SIFLI_EZIP_IRQn);
+    int ezip_ret = irq_attach(ezip_nuttx_irq, _ezip_nuttx_irq_handler, NULL);
+    if(ezip_ret == 0) {
+        up_enable_irq(ezip_nuttx_irq);
+    }
+#elif LV_USE_OS == LV_OS_FREERTOS && defined(LV_SIFLI_EPIC_FREERTOS_IRQ_PRIORITY)
+    HAL_NVIC_SetPriority(LV_SIFLI_EZIP_IRQn, LV_SIFLI_EPIC_FREERTOS_IRQ_PRIORITY, 0);
+    HAL_NVIC_EnableIRQ(LV_SIFLI_EZIP_IRQn);
+#else
+    HAL_NVIC_SetPriority(LV_SIFLI_EZIP_IRQn, LV_SIFLI_EPIC_IRQ_PRIORITY, 0);
+    HAL_NVIC_EnableIRQ(LV_SIFLI_EZIP_IRQn);
+#endif
+#endif
+
+    epic_idle = true;
+}
+
+static void _epic_interrupt_deinit(void)
+{
+#if defined(__ZEPHYR__)
+    irq_disable(LV_SIFLI_EPIC_IRQn);
+#elif defined(__NuttX__)
+    up_disable_irq(LV_SIFLI_EPIC_NUTTX_IRQ(LV_SIFLI_EPIC_IRQn));
+    irq_detach(LV_SIFLI_EPIC_NUTTX_IRQ(LV_SIFLI_EPIC_IRQn));
+#else
+    HAL_NVIC_DisableIRQ(LV_SIFLI_EPIC_IRQn);
+#endif
+
+#ifdef HAL_EZIP_MODULE_ENABLED
+#if defined(__ZEPHYR__)
+    irq_disable(LV_SIFLI_EZIP_IRQn);
+#elif defined(__NuttX__)
+    up_disable_irq(LV_SIFLI_EPIC_NUTTX_IRQ(LV_SIFLI_EZIP_IRQn));
+    irq_detach(LV_SIFLI_EPIC_NUTTX_IRQ(LV_SIFLI_EZIP_IRQn));
+#else
+    HAL_NVIC_DisableIRQ(LV_SIFLI_EZIP_IRQn);
+#endif
+#endif
+
+    epic_idle = true;
+}
+
+static void _epic_run(void)
+{
+#if defined(__NuttX__)
+    epic_wait_failure = false;
+    if(epic_sem_inited) {
+        while(sem_trywait(&epic_sem) == 0) {
+        }
+    }
+#elif LV_USE_OS
+    /* Reset completion token from any previous EPIC job so the next wait only
+     * observes the current run's completion signal. Using LVGL's thread-sync
+     * API ensures cross-platform compatibility without accessing OS internals. */
+    (void)lv_thread_sync_delete(&epic_sync);
+    (void)lv_thread_sync_init(&epic_sync);
+#endif
+    epic_idle = false;
+}
+
+static void _epic_wait(void)
+{
+    if(epic_idle) {
+        return;
+    }
+
+#if LV_USE_OS
+    if(lv_epic_osa_thread_sync_wait() == LV_RESULT_OK) {
+        epic_idle = true;
+    }
+    else {
+        epic_idle = true;
+    }
+#else
+#if defined(__NuttX__)
+    uint32_t waited_us = 0;
+    while(!epic_idle && waited_us < LV_SIFLI_EPIC_WAIT_TIMEOUT_US) {
+        up_udelay(1);
+        waited_us++;
+    }
+
+    if(!epic_idle) {
+        epic_idle = true;
+    }
+#else
+    while(!epic_idle) {
+    }
+#endif
+#endif
+
+}
+
+#endif /*LV_USE_SIFLI_EPIC*/

--- a/src/draw/sifli/epic/lv_sifli_epic_osa.h
+++ b/src/draw/sifli/epic/lv_sifli_epic_osa.h
@@ -1,0 +1,132 @@
+/**
+ * @file lv_sifli_epic_osa.h
+ *
+ */
+
+/**
+ * Copyright 2024 SiFli Technologies
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#ifndef LV_SIFLI_EPIC_OSA_H
+#define LV_SIFLI_EPIC_OSA_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*********************
+ *      INCLUDES
+ *********************/
+
+#include "../../../lv_conf_internal.h"
+#include "../../../misc/lv_types.h"
+
+#if LV_USE_SIFLI_EPIC
+
+/*********************
+ *      DEFINES
+ *********************/
+
+/**********************
+ *      TYPEDEFS
+ **********************/
+
+/**
+ * SiFli EPIC Operating System Abstraction configuration.
+ * This structure provides OS-specific callbacks for interrupt handling and synchronization.
+ */
+typedef struct {
+    /** Callback for EPIC interrupt initialization */
+    void (*epic_interrupt_init)(void);
+
+    /** Callback for EPIC interrupt de-initialization */
+    void (*epic_interrupt_deinit)(void);
+
+    /** Callback for EPIC start (trigger hardware) */
+    void (*epic_run)(void);
+
+    /** Callback for waiting for EPIC completion */
+    void (*epic_wait)(void);
+} epic_osa_cfg_t;
+
+/**********************
+ * GLOBAL PROTOTYPES
+ **********************/
+
+/**
+ * EPIC device interrupt handler exported by the adapter.
+ */
+void EPIC_IRQHandler(void);
+
+/**
+ * EZIP device interrupt handler exported by the adapter.
+ */
+void EZIP_IRQHandler(void);
+
+/**
+ * Get the EPIC default OSA configuration.
+ * @return Pointer to the default EPIC OSA configuration structure
+ */
+epic_osa_cfg_t * epic_get_default_cfg(void);
+
+/**
+ * Initialize EPIC OS abstraction layer.
+ * This function sets up interrupt handlers and synchronization primitives.
+ * @return LV_RESULT_OK on success, LV_RESULT_INVALID otherwise
+ */
+lv_result_t lv_epic_osa_init(void);
+
+/**
+ * De-initialize EPIC OS abstraction layer.
+ * This function cleans up interrupt handlers and synchronization primitives.
+ */
+void lv_epic_osa_deinit(void);
+
+/**
+ * Initialize thread synchronization primitive (semaphore/event).
+ * @return LV_RESULT_OK on success, LV_RESULT_INVALID otherwise
+ */
+lv_result_t lv_epic_osa_thread_sync_init(void);
+
+/**
+ * Wait for EPIC operation completion (blocking).
+ * @return LV_RESULT_OK on success, LV_RESULT_INVALID on timeout
+ */
+lv_result_t lv_epic_osa_thread_sync_wait(void);
+
+/**
+ * Signal EPIC operation completion from ISR.
+ * This function should be called from the EPIC interrupt handler.
+ */
+void lv_epic_osa_thread_sync_signal_isr(void);
+
+/**
+ * Restore the EPIC job state to idle without signaling waiters.
+ * Used when an async kickoff fails before any IRQ can be generated.
+ */
+void lv_epic_osa_set_idle(void);
+
+/**
+ * Return and clear a failed EPIC synchronization wait.
+ * @return true when the last wait timed out or otherwise failed
+ */
+bool lv_epic_osa_take_wait_failure(void);
+
+/**
+ * Delete thread synchronization primitive.
+ */
+void lv_epic_osa_thread_sync_delete(void);
+
+/**********************
+ *      MACROS
+ **********************/
+
+#endif /*LV_USE_SIFLI_EPIC*/
+
+#ifdef __cplusplus
+} /*extern "C"*/
+#endif
+
+#endif /*LV_SIFLI_EPIC_OSA_H*/

--- a/src/draw/sifli/epic/lv_sifli_epic_utils.c
+++ b/src/draw/sifli/epic/lv_sifli_epic_utils.c
@@ -1,0 +1,257 @@
+/**
+ * @file lv_sifli_epic_utils.c
+ *
+ */
+
+/**
+ * Copyright 2024 SiFli Technologies
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+/*********************
+ *      INCLUDES
+ *********************/
+
+#include "lv_sifli_epic_utils.h"
+
+#if LV_USE_SIFLI_EPIC
+#include "../../../misc/lv_area.h"
+#include "string.h"
+
+/*********************
+ *      DEFINES
+ *********************/
+
+
+/**********************
+ *      TYPEDEFS
+ **********************/
+
+/**********************
+ *  STATIC PROTOTYPES
+ **********************/
+
+/**********************
+ *  STATIC VARIABLES
+ **********************/
+
+/**********************
+ *      MACROS
+ **********************/
+
+/**********************
+ *   GLOBAL FUNCTIONS
+ **********************/
+
+uint32_t lv_img_cf_to_epic_cf(lv_color_format_t cf)
+{
+    uint32_t color_mode;
+
+    switch(cf) {
+        /* 2 byte (+alpha) formats */
+        case LV_COLOR_FORMAT_RGB565:
+            color_mode = EPIC_INPUT_RGB565;
+            break;
+
+#ifdef EPIC_SUPPORT_MASK
+        case LV_COLOR_FORMAT_RGB565A8:
+            color_mode = EPIC_INPUT_RGB565;
+            break;
+#endif
+
+        /* 3 byte (+alpha) formats */
+        case LV_COLOR_FORMAT_RGB888:
+            color_mode = EPIC_INPUT_RGB888;
+            break;
+
+        case LV_COLOR_FORMAT_ARGB8888:
+        case LV_COLOR_FORMAT_XRGB8888:
+            color_mode = EPIC_INPUT_ARGB8888;
+            break;
+
+        case LV_COLOR_FORMAT_ARGB8565:
+            color_mode = EPIC_INPUT_ARGB8565;
+            break;
+
+#ifdef EPIC_SUPPORT_A8
+        case LV_COLOR_FORMAT_A8:
+            color_mode = EPIC_INPUT_A8;
+            break;
+#endif
+
+#ifdef EPIC_SUPPORT_A4
+        case LV_COLOR_FORMAT_A4:
+            color_mode = EPIC_INPUT_A4;
+            break;
+#endif
+
+#ifdef EPIC_SUPPORT_A2
+        case LV_COLOR_FORMAT_A2:
+            color_mode = EPIC_INPUT_A2;
+            break;
+#endif
+
+#ifdef EPIC_SUPPORT_L8
+        case LV_COLOR_FORMAT_I8:
+        case LV_COLOR_FORMAT_L8:
+            color_mode = EPIC_INPUT_L8;
+            break;
+#endif
+
+#ifdef EPIC_SUPPORT_YUV
+        case LV_COLOR_FORMAT_I420:
+            color_mode = EPIC_INPUT_YUV420_PLANAR;
+            break;
+
+        case LV_COLOR_FORMAT_YUY2:
+            color_mode = EPIC_INPUT_YUV422_PACKED_YUYV;
+            break;
+
+        case LV_COLOR_FORMAT_UYVY:
+            color_mode = EPIC_INPUT_YUV422_PACKED_UYVY;
+            break;
+#endif
+
+        default:
+            LV_ASSERT(false);
+            color_mode = EPIC_INPUT_RGB565; /* Fallback */
+            break;
+    }
+
+    return color_mode;
+}
+
+EPIC_ColorDef lv_color_to_epic_color(lv_color_t color, lv_opa_t opa)
+{
+    EPIC_ColorDef c;
+    c.ch.color_r = color.red;
+    c.ch.color_g = color.green;
+    c.ch.color_b = color.blue;
+    c.ch.alpha = opa;
+    return c;
+}
+
+uint32_t lv_epic_setup_layers(EPIC_LayerConfigTypeDef * epic_bg_layer,
+                              EPIC_LayerConfigTypeDef * epic_output_layer,
+                              lv_draw_task_t * draw_task,
+                              const lv_area_t * coords)
+{
+    const lv_draw_dsc_base_t * draw_dsc_base = (const lv_draw_dsc_base_t *)draw_task->draw_dsc;
+    lv_layer_t * layer = draw_dsc_base->layer;
+    uint16_t dest_total_width;
+
+    if(layer == NULL) {
+        return 1;
+    }
+
+    lv_area_t blend_area;
+    if(!_lv_area_intersect(&blend_area, coords, &draw_task->clip_area)) {
+        return 1; /* Fully clipped, nothing to do */
+    }
+
+    if(!_lv_area_intersect(&blend_area, &blend_area, &layer->buf_area)) {
+        return 1; /* Fully clipped, nothing to do */
+    }
+
+    lv_color_format_t dest_cf = layer->color_format;
+    dest_total_width = layer->draw_buf ? lv_epic_stride_to_width(layer->draw_buf->header.stride, dest_cf) :
+                       lv_area_get_width(&layer->buf_area);
+
+    /* Setup background layer */
+    HAL_EPIC_LayerConfigInit(epic_bg_layer);
+    epic_bg_layer->color_en = false;
+    epic_bg_layer->data = (uint8_t *)lv_draw_layer_go_to_xy(layer, 0, 0);
+    epic_bg_layer->color_mode = lv_img_cf_to_epic_cf(dest_cf);
+    epic_bg_layer->width = lv_area_get_width(&layer->buf_area);
+    epic_bg_layer->total_width = dest_total_width;
+    epic_bg_layer->height = lv_area_get_height(&layer->buf_area);
+    epic_bg_layer->x_offset = layer->buf_area.x1;
+    epic_bg_layer->y_offset = layer->buf_area.y1;
+
+    /* Setup output layer */
+    memcpy(epic_output_layer, epic_bg_layer, sizeof(*epic_output_layer));
+    epic_output_layer->width = lv_area_get_width(&blend_area);
+    epic_output_layer->height = lv_area_get_height(&blend_area);
+    epic_output_layer->x_offset = blend_area.x1;
+    epic_output_layer->y_offset = blend_area.y1;
+    epic_output_layer->data = (uint8_t *)lv_draw_layer_go_to_xy(layer,
+                                                                blend_area.x1 - layer->buf_area.x1,
+                                                                blend_area.y1 - layer->buf_area.y1);
+
+    LV_ASSERT((epic_output_layer->height * epic_output_layer->width) <= EPIC_MAX_PIXELS);
+
+    return 0; /* Success */
+}
+
+bool lv_epic_cf_supported(lv_color_format_t cf, uint32_t flags)
+{
+    /* EZIP images */
+    if((LV_COLOR_FORMAT_RAW == cf || LV_COLOR_FORMAT_RAW_ALPHA == cf) &&
+       (0 != (flags & LV_IMAGE_FLAGS_EZIP))) {
+        return true;
+    }
+
+#if defined(EPIC_INPUT_JPEG)
+    if((LV_COLOR_FORMAT_RAW == cf || LV_COLOR_FORMAT_RAW_ALPHA == cf) &&
+       (0 != (flags & LV_IMAGE_FLAGS_JPEG))) {
+        return true;
+    }
+#endif
+
+    /* Normal images */
+    if(LV_COLOR_FORMAT_RGB565 == cf ||
+       LV_COLOR_FORMAT_ARGB8565 == cf ||
+       LV_COLOR_FORMAT_RGB888 == cf ||
+       LV_COLOR_FORMAT_ARGB8888 == cf ||
+       LV_COLOR_FORMAT_XRGB8888 == cf) {
+        return true;
+    }
+
+#ifdef EPIC_SUPPORT_A8
+    if(LV_COLOR_FORMAT_A8 == cf) return true;
+#endif
+
+#ifdef EPIC_SUPPORT_MASK
+    if(LV_COLOR_FORMAT_RGB565A8 == cf) return true;
+#endif
+
+#ifdef EPIC_SUPPORT_A4
+    if(LV_COLOR_FORMAT_A4 == cf) return true;
+#endif
+
+#ifdef EPIC_SUPPORT_A2
+    if(LV_COLOR_FORMAT_A2 == cf) return true;
+#endif
+
+#ifdef EPIC_SUPPORT_L8
+    if((LV_COLOR_FORMAT_I8 == cf) || (LV_COLOR_FORMAT_L8 == cf)) return true;
+#endif
+
+#ifdef EPIC_SUPPORT_YUV
+    if(LV_COLOR_FORMAT_I420 == cf ||
+       LV_COLOR_FORMAT_YUY2 == cf ||
+       LV_COLOR_FORMAT_UYVY == cf) {
+        return true;
+    }
+#endif
+
+    return false;
+}
+
+uint16_t lv_epic_stride_to_width(uint32_t stride, lv_color_format_t cf)
+{
+    uint8_t bpp = lv_color_format_get_bpp(cf);
+
+    if(bpp == 0) {
+        return 0;
+    }
+
+    return (uint16_t)((stride * 8U) / bpp);
+}
+
+/**********************
+ *   STATIC FUNCTIONS
+ **********************/
+
+#endif /*LV_USE_SIFLI_EPIC*/

--- a/src/draw/sifli/epic/lv_sifli_epic_utils.h
+++ b/src/draw/sifli/epic/lv_sifli_epic_utils.h
@@ -1,0 +1,113 @@
+/**
+ * @file lv_sifli_epic_utils.h
+ *
+ */
+
+/**
+ * Copyright 2024 SiFli Technologies
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#ifndef LV_SIFLI_EPIC_UTILS_H
+#define LV_SIFLI_EPIC_UTILS_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*********************
+ *      INCLUDES
+ *********************/
+
+#include "../../../lv_conf_internal.h"
+
+#if LV_USE_SIFLI_EPIC
+#include "../../sw/lv_draw_sw.h"
+#include "../../lv_draw.h"
+#include "../../../stdlib/lv_string.h"
+#include "lv_sifli_epic_cfg.h"
+
+/*********************
+ *      DEFINES
+ *********************/
+
+#if LV_USE_SIFLI_EPIC_ASSERT
+#define EPIC_ASSERT(expr) LV_ASSERT(expr)
+#else
+#define EPIC_ASSERT(expr)
+#endif
+
+#define EPIC_ASSERT_MSG(expr, msg)                                   \
+    do {                                                             \
+        if(!(expr)) {                                                \
+            LV_LOG_ERROR(msg);                                       \
+            EPIC_ASSERT(false);                                      \
+        }                                                            \
+    } while(0)
+
+/**********************
+ *      TYPEDEFS
+ **********************/
+
+/**********************
+ * GLOBAL PROTOTYPES
+ **********************/
+
+/**
+ * Convert LVGL color format to EPIC color format.
+ * @param cf LVGL color format
+ * @return EPIC color format constant
+ */
+uint32_t lv_img_cf_to_epic_cf(lv_color_format_t cf);
+
+/**
+ * Convert LVGL color to EPIC color structure.
+ * @param color LVGL color
+ * @param opa Opacity value
+ * @return EPIC color structure
+ */
+EPIC_ColorDef lv_color_to_epic_color(lv_color_t color, lv_opa_t opa);
+
+/**
+ * Setup background and output layers for EPIC operation.
+ * This function configures the EPIC layers based on the draw task.
+ *
+ * @param epic_bg_layer Pointer to background layer configuration
+ * @param epic_output_layer Pointer to output layer configuration
+ * @param draw_task Draw task containing layer information
+ * @param coords Coordinates to draw
+ * @return 0 on success, non-zero if fully clipped
+ */
+uint32_t lv_epic_setup_layers(EPIC_LayerConfigTypeDef * epic_bg_layer,
+                              EPIC_LayerConfigTypeDef * epic_output_layer,
+                              lv_draw_task_t * draw_task,
+                              const lv_area_t * coords);
+
+/**
+ * Check if color format is supported by EPIC.
+ * @param cf LVGL color format
+ * @param flags Image flags
+ * @return true if supported, false otherwise
+ */
+bool lv_epic_cf_supported(lv_color_format_t cf, uint32_t flags);
+
+/**
+ * Convert a stride in bytes to a width in pixels for a given color format.
+ * @param stride Byte stride
+ * @param cf LVGL color format
+ * @return Width in pixels
+ */
+uint16_t lv_epic_stride_to_width(uint32_t stride, lv_color_format_t cf);
+
+/**********************
+ *      MACROS
+ **********************/
+
+#endif /*LV_USE_SIFLI_EPIC*/
+
+#ifdef __cplusplus
+} /*extern "C"*/
+#endif
+
+#endif /*LV_SIFLI_EPIC_UTILS_H*/

--- a/src/lv_conf_internal.h
+++ b/src/lv_conf_internal.h
@@ -516,6 +516,33 @@
     #endif
 #endif
 
+/* Use SiFli EPIC draw accelerator. */
+#ifndef LV_USE_SIFLI_EPIC
+    #ifdef CONFIG_LV_USE_SIFLI_EPIC
+        #define LV_USE_SIFLI_EPIC CONFIG_LV_USE_SIFLI_EPIC
+    #else
+        #define LV_USE_SIFLI_EPIC 0
+    #endif
+#endif
+
+#if LV_USE_SIFLI_EPIC
+    #ifndef LV_USE_SIFLI_EPIC_DRAW_THREAD
+        #ifdef CONFIG_LV_USE_SIFLI_EPIC_DRAW_THREAD
+            #define LV_USE_SIFLI_EPIC_DRAW_THREAD CONFIG_LV_USE_SIFLI_EPIC_DRAW_THREAD
+        #else
+            #define LV_USE_SIFLI_EPIC_DRAW_THREAD 0
+        #endif
+    #endif
+
+    #ifndef LV_USE_SIFLI_EPIC_ASSERT
+        #ifdef CONFIG_LV_USE_SIFLI_EPIC_ASSERT
+            #define LV_USE_SIFLI_EPIC_ASSERT CONFIG_LV_USE_SIFLI_EPIC_ASSERT
+        #else
+            #define LV_USE_SIFLI_EPIC_ASSERT 0
+        #endif
+    #endif
+#endif
+
 /* Use VG-Lite GPU. */
 #ifndef LV_USE_DRAW_VG_LITE
     #ifdef CONFIG_LV_USE_DRAW_VG_LITE
@@ -656,6 +683,16 @@
         #define LV_USE_DRAW_G2D 0
     #endif
 #endif
+
+/* Use SiFli EPIC GPU for hardware acceleration. */
+#ifndef LV_USE_DRAW_EPIC
+    #ifdef CONFIG_LV_USE_DRAW_EPIC
+        #define LV_USE_DRAW_EPIC CONFIG_LV_USE_DRAW_EPIC
+    #else
+        #define LV_USE_DRAW_EPIC 0
+    #endif
+#endif
+
 
 /*=======================
  * FEATURE CONFIGURATION

--- a/src/lv_init.c
+++ b/src/lv_init.c
@@ -54,6 +54,9 @@
 #if LV_USE_DRAW_G2D
     #include "draw/sunxi_g2d/lv_draw_g2d.h"
 #endif
+#if LV_USE_SIFLI_EPIC
+    #include "draw/sifli/epic/lv_draw_sifli_epic.h"
+#endif
 #if LV_USE_WINDOWS
     #include "drivers/windows/lv_windows_context.h"
 #endif
@@ -205,8 +208,16 @@ void lv_init(void)
     lv_draw_g2d_init();
 #endif
 
+#if LV_USE_SIFLI_EPIC
+    lv_draw_sifli_epic_init();
+#endif
+
 #if LV_USE_DRAW_DAVE2D
     lv_draw_dave2d_init();
+#endif
+
+#if LV_USE_DRAW_EPIC
+    lv_draw_epic_init();
 #endif
 
 #if LV_USE_DRAW_SDL
@@ -417,6 +428,10 @@ void lv_deinit(void)
 
 #if LV_USE_DRAW_G2D
     lv_draw_g2d_deinit();
+#endif
+
+#if LV_USE_SIFLI_EPIC
+    lv_draw_sifli_epic_deinit();
 #endif
 
     lv_draw_deinit();

--- a/src/osal/lv_os_private.h
+++ b/src/osal/lv_os_private.h
@@ -1,0 +1,279 @@
+/**
+ * @file lv_os_private.h
+ *
+ */
+
+#ifndef LV_OS_PRIVATE_H
+#define LV_OS_PRIVATE_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*********************
+ *    OS OPTIONS
+ *********************/
+
+/*********************
+ *      INCLUDES
+ *********************/
+#include "../lv_conf_internal.h"
+
+#include "lv_os.h"
+#include "../misc/lv_types.h"
+
+#ifdef __linux__
+#include "lv_linux.h"
+#endif
+
+#if LV_USE_OS == LV_OS_NONE
+#include "lv_os_none.h"
+#elif LV_USE_OS == LV_OS_PTHREAD
+#include "lv_pthread.h"
+#elif LV_USE_OS == LV_OS_FREERTOS
+#include "lv_freertos.h"
+#elif LV_USE_OS == LV_OS_CMSIS_RTOS2
+#include "lv_cmsis_rtos2.h"
+#elif LV_USE_OS == LV_OS_RTTHREAD
+#include "lv_rtthread.h"
+#elif LV_USE_OS == LV_OS_WINDOWS
+#include "lv_windows.h"
+#elif LV_USE_OS == LV_OS_MQX
+#include "lv_mqx.h"
+#elif LV_USE_OS == LV_OS_SDL2
+#include "lv_sdl2.h"
+#elif LV_USE_OS == LV_OS_CUSTOM
+#include LV_OS_CUSTOM_INCLUDE
+#endif
+
+/*********************
+ *      DEFINES
+ *********************/
+
+/**********************
+ *      TYPEDEFS
+ **********************/
+typedef enum {
+    LV_THREAD_PRIO_LOWEST,
+    LV_THREAD_PRIO_LOW,
+    LV_THREAD_PRIO_MID,
+    LV_THREAD_PRIO_HIGH,
+    LV_THREAD_PRIO_HIGHEST,
+} lv_thread_prio_t;
+
+/**********************
+ * GLOBAL PROTOTYPES
+ **********************/
+
+/**
+ * Initialize the OS layer
+ */
+void lv_os_init(void);
+
+/**
+ * Set it for `LV_SYSMON_GET_IDLE` to show the CPU usage
+ * @return the idle percentage since the last call
+ */
+uint32_t lv_os_get_idle_percent(void);
+
+#if LV_SYSMON_PROC_IDLE_AVAILABLE
+
+uint32_t lv_os_get_proc_idle_percent(void);
+
+#endif
+
+#if LV_USE_OS != LV_OS_NONE
+
+/*----------------------------------------
+ * These functions needs to be implemented
+ * for specific operating systems
+ *---------------------------------------*/
+
+/**
+ * Create a new thread
+ * @param thread        a variable in which the thread will be stored
+ * @param name          the name of the thread
+ * @param prio          priority of the thread
+ * @param callback      function of the thread
+ * @param stack_size    stack size in bytes
+ * @param user_data     arbitrary data, will be available in the callback
+ * @return              LV_RESULT_OK: success; LV_RESULT_INVALID: failure
+ */
+lv_result_t lv_thread_init(lv_thread_t * thread, const char * const name,
+                           lv_thread_prio_t prio, void (*callback)(void *), size_t stack_size,
+                           void * user_data);
+
+/**
+ * Delete a thread
+ * @param thread        the thread to delete
+ * @return              LV_RESULT_OK: success; LV_RESULT_INVALID: failure
+ */
+lv_result_t lv_thread_delete(lv_thread_t * thread);
+
+/**
+ * Create a mutex
+ * @param mutex         a variable in which the thread will be stored
+ * @return              LV_RESULT_OK: success; LV_RESULT_INVALID: failure
+ */
+lv_result_t lv_mutex_init(lv_mutex_t * mutex);
+
+/**
+ * Lock a mutex
+ * @param mutex         the mutex to lock
+ * @return              LV_RESULT_OK: success; LV_RESULT_INVALID: failure
+ */
+lv_result_t lv_mutex_lock(lv_mutex_t * mutex);
+
+/**
+ * Lock a mutex from interrupt
+ * @param mutex         the mutex to lock
+ * @return              LV_RESULT_OK: success; LV_RESULT_INVALID: failure
+ */
+lv_result_t lv_mutex_lock_isr(lv_mutex_t * mutex);
+
+/**
+ * Unlock a mutex
+ * @param mutex         the mutex to unlock
+ * @return              LV_RESULT_OK: success; LV_RESULT_INVALID: failure
+ */
+lv_result_t lv_mutex_unlock(lv_mutex_t * mutex);
+
+/**
+ * Delete a mutex
+ * @param mutex         the mutex to delete
+ * @return              LV_RESULT_OK: success; LV_RESULT_INVALID: failure
+ */
+lv_result_t lv_mutex_delete(lv_mutex_t * mutex);
+
+/**
+ * Create a thread synchronization object
+ * @param sync          a variable in which the sync will be stored
+ * @return              LV_RESULT_OK: success; LV_RESULT_INVALID: failure
+ */
+lv_result_t lv_thread_sync_init(lv_thread_sync_t * sync);
+
+/**
+ * Wait for a "signal" on a sync object
+ * @param sync      a sync object
+ * @return          LV_RESULT_OK: success; LV_RESULT_INVALID: failure
+ */
+lv_result_t lv_thread_sync_wait(lv_thread_sync_t * sync);
+
+/**
+ * Send a wake-up signal to a sync object
+ * @param sync      a sync object
+ * @return          LV_RESULT_OK: success; LV_RESULT_INVALID: failure
+ */
+lv_result_t lv_thread_sync_signal(lv_thread_sync_t * sync);
+
+/**
+ * Send a wake-up signal to a sync object from interrupt
+ * @param sync      a sync object
+ * @return          LV_RESULT_OK: success; LV_RESULT_INVALID: failure
+ */
+lv_result_t lv_thread_sync_signal_isr(lv_thread_sync_t * sync);
+
+/**
+ * Delete a sync object
+ * @param sync      a sync object to delete
+ * @return          LV_RESULT_OK: success; LV_RESULT_INVALID: failure
+ */
+lv_result_t lv_thread_sync_delete(lv_thread_sync_t * sync);
+
+#else
+
+/* Since compilation does not necessarily optimize cross-file empty functions well
+ * (-O3 optimization alone is not enough unless LTO optimization is enabled),
+ * In the absence of an operating system, use inline functions to help compile
+ * optimizations and avoid the call overhead of the OS API to ensure no performance penalty.
+ */
+
+static inline lv_result_t lv_thread_init(lv_thread_t * thread, const char * const name, lv_thread_prio_t prio,
+                                         void (*callback)(void *), size_t stack_size, void * user_data)
+{
+    LV_UNUSED(thread);
+    LV_UNUSED(name);
+    LV_UNUSED(callback);
+    LV_UNUSED(prio);
+    LV_UNUSED(stack_size);
+    LV_UNUSED(user_data);
+    return LV_RESULT_INVALID;
+}
+
+static inline lv_result_t lv_thread_delete(lv_thread_t * thread)
+{
+    LV_UNUSED(thread);
+    return LV_RESULT_INVALID;
+}
+
+static inline lv_result_t lv_mutex_init(lv_mutex_t * mutex)
+{
+    LV_UNUSED(mutex);
+    return LV_RESULT_OK;
+}
+
+static inline lv_result_t lv_mutex_lock(lv_mutex_t * mutex)
+{
+    LV_UNUSED(mutex);
+    return LV_RESULT_OK;
+}
+
+static inline lv_result_t lv_mutex_lock_isr(lv_mutex_t * mutex)
+{
+    LV_UNUSED(mutex);
+    return LV_RESULT_OK;
+}
+
+static inline lv_result_t lv_mutex_unlock(lv_mutex_t * mutex)
+{
+    LV_UNUSED(mutex);
+    return LV_RESULT_OK;
+}
+
+static inline lv_result_t lv_mutex_delete(lv_mutex_t * mutex)
+{
+    LV_UNUSED(mutex);
+    return LV_RESULT_OK;
+}
+
+static inline lv_result_t lv_thread_sync_init(lv_thread_sync_t * sync)
+{
+    LV_UNUSED(sync);
+    return LV_RESULT_INVALID;
+}
+
+static inline lv_result_t lv_thread_sync_wait(lv_thread_sync_t * sync)
+{
+    LV_UNUSED(sync);
+    return LV_RESULT_INVALID;
+}
+
+static inline lv_result_t lv_thread_sync_signal(lv_thread_sync_t * sync)
+{
+    LV_UNUSED(sync);
+    return LV_RESULT_INVALID;
+}
+
+static inline lv_result_t lv_thread_sync_signal_isr(lv_thread_sync_t * sync)
+{
+    LV_UNUSED(sync);
+    return LV_RESULT_INVALID;
+}
+
+static inline lv_result_t lv_thread_sync_delete(lv_thread_sync_t * sync)
+{
+    LV_UNUSED(sync);
+    return LV_RESULT_INVALID;
+}
+
+#endif /*LV_USE_OS != LV_OS_NONE*/
+
+/**********************
+ *      MACROS
+ **********************/
+
+#ifdef __cplusplus
+} /*extern "C"*/
+#endif
+
+#endif /*LV_OS_PRIVATE_H*/


### PR DESCRIPTION
## LVGL SiFli EPIC 硬件加速后端

为 **contest2026_427_xinpingqihe** 的 PhyWear 作品（黄山派 SF32LB52）新增 LVGL **EPIC GPU 硬件加速**后端：

- `src/draw/sifli/epic/`：EPIC 绘制单元（FILL / BORDER / IMAGE / LABEL / LAYER），配置/OSA/工具。
- `src/lv_conf_internal.h` + `src/lv_init.c`：EPIC 开关与初始化接入。
- `src/osal/lv_os_private.h`：构建所需 OS 抽象头。

效果：真机 SF32LB52 上 LVGL 渲染 **3 → 43 FPS**（全场景平均，flush 0ms）。

按官方指引「参赛仓库不足以满足适配需求时可在公共仓提交 PR」提交，使评委 `repo sync` 后可编译并复现 EPIC 加速。

改动为新增文件 + 少量接入，共 18 文件 / +3852 行。